### PR TITLE
Correção: Change this code to not construct SQL queries directly from user-controlled data.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,7 +1,9 @@
+
+
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.JwtParser;
@@ -37,16 +39,16 @@ public class User {
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
+    PreparedStatement pstmt = null;
     User user = null;
     try {
       Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
       System.out.println("Opened database successfully");
 
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      String query = "select * from users where username = ? limit 1";
+      pstmt = cxn.prepareStatement(query);
+      pstmt.setString(1, un);
+      ResultSet rs = pstmt.executeQuery();
       if (rs.next()) {
         String user_id = rs.getString("user_id");
         String username = rs.getString("username");


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCOcRY9aYd46TEDemN
- Arquivo: src/main/java/com/scalesec/vulnado/User.java
- Severidade: BLOCKER
*/Explicação:/*
**Risco:** Alto

**Explicação:** O código apresenta uma vulnerabilidade de Injeção de SQL no método `fetch`. Injeção de SQL ocorre quando o código permite que um atacante insira ou manipule instruções SQL através da entrada de dados em uma aplicação. Isso pode levar a acesso não autorizado, manipulação ou exclusão de dados no banco de dados.

O problema está na seguinte linha:

```java
String query = "select * from users where username = '" + un + "' limit 1";
```

A variável `un` é concatenada diretamente na consulta SQL sem qualquer validação ou parametrização, permitindo que um atacante insira comandos SQL maliciosos no `username`.

**Correção:** Para resolver esta vulnerabilidade, devemos utilizar consultas parametrizadas, que impedem a injeção de SQL, substituindo a concatenação do valor direto na consulta.

```java
String query = "select * from users where username = ? limit 1";
PreparedStatement pstmt = cxn.prepareStatement(query);
pstmt.setString(1, un);
ResultSet rs = pstmt.executeQuery();
```


```