### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +14,11 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABc
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Moderado

**Explicação:** A vulnerabilidade "Make sure allowing safe and unsafe HTTP methods is safe here" refere-se ao fato de que o código pode estar permitindo métodos HTTP inseguros ou inadequados para o caso de uso pretendido. Os métodos HTTP, como GET, POST, PUT, DELETE, etc., têm objetivos específicos e a utilização de métodos inseguros ou incorretos pode levar a problemas de segurança, como exposição de dados confidenciais, modificação não autorizada de dados e até mesmo ataques de negação de serviço.

No caso do código fornecido, ambos os endpoints `/links` e `/links-v2` não especificam qual método HTTP é permitido, portanto, todos os métodos HTTP podem ser usados. A função principal desses endpoints é somente obter informações (links) e não há necessidade de permitir a modificação dos dados. Para garantir a segurança, é recomendável permitir apenas o método HTTP seguro GET em ambos os endpoints.

**Correção:** 
```java
@RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
```
```java
@RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
```

