### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +14,12 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABb
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** A vulnerabilidade em questão está relacionada à possibilidade de permitir métodos HTTP não seguros nos endpoints da API. Permitir métodos HTTP inseguros pode resultar em ataques ou manipulações indesejadas dos dados expostos pelo serviço. No código atual, não há restrições específicas sobre quais métodos HTTP são permitidos, potencialmente tornando a aplicação mais vulnerável a ataques.

**Correção:** A correção consiste em limitar os métodos HTTP permitidos aos endpoints, permitindo apenas métodos seguros (GET, POST, PUT, DELETE, etc.) e bloqueando aqueles que são considerados inseguros (OPTIONS, TRACE, etc.). Adicionar a anotação `@RequestMapping` com o atributo `method` nos métodos `links` e `linksV2` implementa essa correção.

```java
@RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
List<String> links(@RequestParam String url) throws IOException{
  return LinkLister.getLinks(url);
}

@RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
List<String> linksV2(@RequestParam String url) throws BadRequest{
  return LinkLister.getLinksV2(url);
}
```

