### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,12 +14,12 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
+  List<String> links(@RequestParam("url") String url) throws IOException {
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
+  List<String> linksV2(@RequestParam("url") String url) throws BadRequest {
     return LinkLister.getLinksV2(url);
   }
 }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABc
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** A vulnerabilidade mencionada é relacionada aos métodos HTTP permitidos para os endpoints da aplicação. O código não especifica quais métodos HTTP são permitidos para cada endpoint (`/links` e `/links-v2`). Isso significa que métodos HTTP inseguros, como `PUT` e `DELETE`, podem ser utilizados nessas rotas, o que pode colocar a aplicação em risco de ataques.

**Correção:** Para corrigir a vulnerabilidade, devemos especificar os métodos HTTP permitidos para cada endpoint (neste caso, o método `GET` é adequado), adicionando o parâmetro `method` no anotação `@RequestMapping`.

```java
@RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
```

```java
@RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
```

