### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,6 @@
+-
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +15,12 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABb
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** A vulnerabilidade "Make sure allowing safe and unsafe HTTP methods is safe here" está relacionada ao fato de que métodos HTTP inseguros podem ser utilizados para acessar as rotas do controlador. Métodos HTTP inseguros, como DELETE e PUT, podem permitir que um atacante execute ações indesejadas, como modificar ou excluir dados. Portanto, é importante garantir que apenas métodos seguros, como GET e POST, sejam permitidos.

**Correção:** Vamos adicionar explicitamente as propriedades "method" nos endpoints, permitindo apenas métodos GET para que os atacantes não possam executar ações indesejadas.

```java
@RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
@RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
```


