### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -8,15 +10,15 @@ import java.util.List;
 import java.io.Serializable;
 import java.io.IOException;
 
-
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABc
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** A vulnerabilidade mencionada, "Make sure allowing safe and unsafe HTTP methods is safe here", refere-se à possibilidade de permitir métodos HTTP inseguros em seu aplicativo. Métodos HTTP como GET e HEAD são considerados seguros, pois não resultam em alterações nos estados do recurso que eles acessam, enquanto métodos como POST, PUT, DELETE e PATCH são considerados inseguros, pois podem resultar em alterações de estado no recurso.

Nesse caso, o controlador `LinksController` provavelmente permite todos os métodos HTTP para seus endpoints `/links` e `/links-v2` por padrão. Um atacante pode tentar usar métodos HTTP inseguros em endpoints que não deveriam permitir tal ação, expondo sua aplicação a riscos.

**Correção:** Para garantir que apenas os métodos HTTP seguros sejam permitidos nessas rotas, você pode adicionar a anotação `@RequestMapping(method = RequestMethod.GET)` às definições dos métodos links e linksV2, limitando-os ao método HTTP GET.

```java
@RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
List<String> links(@RequestParam String url) throws IOException{
  return LinkLister.getLinks(url);
}

@RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
List<String> linksV2(@RequestParam String url) throws BadRequest{
  return LinkLister.getLinksV2(url);
}
```

