### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +14,11 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABb
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** A vulnerabilidade "Make sure allowing safe and unsafe HTTP methods is safe here" refere-se aos métodos HTTP permitidos para a API. Por padrão, o Spring MVC permite todos os métodos HTTP na API, o que pode levar a ações indesejadas e insegurança no aplicativo.

Quando você permite que todos os métodos HTTP sejam executados em um endpoint, isso pode resultar em alterações não autorizadas nos dados do servidor, como adicionar, modificar ou excluir registros. Portanto, é importante limitar os métodos HTTP permitidos de acordo com os requisitos do aplicativo.

**Correção:** Neste caso, você só está lendo dados, por isso é seguro limitar os métodos HTTP permitidos para GET. Para fazer isso, especifique o atributo `method` do `@RequestMapping` para limitar os métodos HTTP permitidos.

```java
@RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
@RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
```


