### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +14,11 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABc
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** A vulnerabilidade "Make sure allowing safe and unsafe HTTP methods is safe here" está relacionada aos métodos HTTP permitidos para os recursos da aplicação. No código fornecido, o problema está na falta de restrição do método HTTP para os endpoints `/links` e `/links-v2`. O uso de métodos HTTP inadequados pode permitir ações maliciosas, como alteração de dados, e facilitar outros ataques.

**Correção:** Adicionar a restrição do método HTTP para "GET" nos endpoints `/links` e `/links-v2`.

```java
@RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
@RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
```

