### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +14,12 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABb
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** A vulnerabilidade "Make sure allowing safe and unsafe HTTP methods is safe here" indica que o código permite o uso de métodos HTTP inseguros. Isso pode levar a sérios problemas de segurança, como ataques CSRF (Cross-Site Request Forgery) ou ataques de injeção.

Para corrigir essa vulnerabilidade, é importante restringir quais métodos HTTP são permitidos para as rotas fornecidas. No exemplo dado, utilizaremos a anotação `@RequestMapping` para permitir apenas métodos HTTP seguros, como GET, e bloquear HTTP inseguros, como PUT, POST, DELETE, etc.

**Correção:**
```java
@RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
```
```java
@RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
```

