### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,6 @@
+
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +15,11 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABc
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** O código atual não especifica qual método HTTP deve ser usado para os endpoints, ou seja, qualquer requisição com qualquer método HTTP como GET, POST, DELETE, etc., será aceita e processada. Permitir métodos HTTP inseguros ou inadequados pode permitir que um atacante realize ataques, como modificações indevidas de dados ou acesso não autorizado.

**Correção:** Para corrigir a vulnerabilidade, devemos especificar os métodos HTTP apropriados para cada endpoint. Presumindo que ambos os endpoints devem ser acessados ​​apenas por meio do método GET, podemos adicionar o parâmetro "method" em cada anotação `@RequestMapping`:

```java
@RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
```

```java
@RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
```


