### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -8,14 +10,15 @@ import java.util.List;
 import java.io.Serializable;
 import java.io.IOException;
 
-
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
+  @CrossOrigin(methods = {RequestMethod.GET, RequestMethod.HEAD})
   @RequestMapping(value = "/links", produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
+  @CrossOrigin(methods = {RequestMethod.GET, RequestMethod.HEAD})
   @RequestMapping(value = "/links-v2", produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABb
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** A vulnerabilidade mencionada está relacionada ao fato do código não tratar adequadamente a permissão de métodos HTTP que são considerados seguros e inseguros. Neste caso, o controle é amplo e permite todas as solicitações sem verificar se eles estão vindo de um método seguro permitido. Deixar esta vulnerabilidade sem tratamento permite que um atacante explore possíveis ataques, como o Cross-Site Request Forgery (CSRF).

**Correção:** Adicione a anotação `@CrossOrigin` com o atributo `methods` que permitem apenas métodos HTTP seguros como GET e HEAD no controlador. Isso limitará as solicitações a apenas os métodos seguros permitidos.

```java
@CrossOrigin(methods = {RequestMethod.GET, RequestMethod.HEAD})
@RequestMapping(value = "/links", produces = "application/json")
List<String> links(@RequestParam String url) throws IOException{
  return LinkLister.getLinks(url);
}
```

```java
@CrossOrigin(methods = {RequestMethod.GET, RequestMethod.HEAD})
@RequestMapping(value = "/links-v2", produces = "application/json")
List<String> linksV2(@RequestParam String url) throws BadRequest{
  return LinkLister.getLinksV2(url);
}
```

