### PR TITLE
Correção: Change this code to not construct SQL queries directly from user-controlled data.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,7 +1,9 @@
+
+
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.JwtParser;
@@ -37,16 +39,19 @@ public class User {
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
+    PreparedStatement pstmt = null;
     User user = null;
     try {
       Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
+
       System.out.println("Opened database successfully");
 
-      String query = "select * from users where username = '" + un + "' limit 1";
+      String query = "select * from users where username = ? limit 1";
+      pstmt = cxn.prepareStatement(query);
+      pstmt.setString(1, un);
+      
       System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      ResultSet rs = pstmt.executeQuery();
       if (rs.next()) {
         String user_id = rs.getString("user_id");
         String username = rs.getString("username");


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCOcRY9aYd46TEDemN
- Arquivo: src/main/java/com/scalesec/vulnado/User.java
- Severidade: BLOCKER
*/Explicação:/*
**Risco:** Alto

**Explicação:** A vulnerabilidade encontrada no código se refere à injeção de SQL no método `fetch()`. A injeção de SQL ocorre quando um invasor consegue inserir comandos SQL maliciosos que são executados pelo sistema como se fossem consultas legítimas. Isso pode levar à obtenção de informações não autorizadas, modificação e exclusão de dados.

A injeção de SQL ocorre na seguinte linha de código:

```java
String query = "select * from users where username = '" + un + "' limit 1";
```

Neste caso, a variável `un` não está sendo sanitizada antes de ser usada na consulta SQL, permitindo que um invasor insira comandos SQL maliciosos através do parâmetro `un`.

**Correção:** Utilize `PreparedStatement` para evitar a injeção de SQL. O `PreparedStatement` permite definir parâmetros com marcadores de posição, garantindo que o valor passado seja tratado adequadamente e evite vulnerabilidades de injeção de SQL.

```java
String query = "select * from users where username = ? limit 1";
PreparedStatement pstmt = cxn.prepareStatement(query);
pstmt.setString(1, un);
ResultSet rs = pstmt.executeQuery();
```

