### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +14,11 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABc
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** O código disponibiliza duas APIs para listar os links de uma página da web fornecida pelo parâmetro `url`. No entanto, todas as solicitações HTTP como GET, POST, PUT, DELETE etc. são permitidas devido à falta de restrição nos métodos HTTP. Permitir todos os métodos HTTP pode levar a consequências indesejadas, como modificações ou exclusão de dados. Para restringir a vulnerabilidade, é necessário permitir apenas os métodos HTTP desejados e seguros.

**Correção:** Adicione a anotação `@RequestMapping` especificando os métodos HTTP permitidos (por exemplo, apenas GET).

```java
@RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
```

```java
@RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
```

