### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +14,11 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABb
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** A vulnerabilidade "Make sure allowing safe and unsafe HTTP methods is safe here" indica que o código pode estar permitindo o uso de métodos HTTP inseguros ou inadequados. No código fornecido, os métodos HTTP padrão, como GET, POST, PUT, DELETE, etc., são permitidos por padrão para os endpoints `/links` e `/links-v2`. Isso pode levar a problemas de segurança se métodos inadequados ou inseguros forem utilizados nessas rotas.

**Correção:** Para corrigir a vulnerabilidade, devemos especificar explicitamente os métodos HTTP permitidos para cada endpoint. No caso deste código, assumiremos que o método GET é apropriado para uso.

```java
@RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
```

```java
@RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
```

