### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +14,11 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABc
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** A vulnerabilidade "Make sure allowing safe and unsafe HTTP methods is safe here" refere-se ao fato de que o código expõe um endpoint sem explicitar quais métodos HTTP estão permitidos. Isso pode levar a ataques potenciais, permitindo que os atacantes explorem métodos HTTP inseguros ou inadequados para o propósito do endpoint.

**Correção:** Uma solução prática é especificar explicitamente os métodos HTTP permitidos usando a anotação `@RequestMapping`. Neste caso, como as rotas devem retornar apenas informações de links para o usuário, é seguro usar o método GET.

```java
@RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
```

E similarmente para a rota "/links-v2"

```java
@RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
```

