### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +14,12 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABb
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** A vulnerabilidade encontrada "Make sure allowing safe and unsafe HTTP methods is safe here" refere-se à possibilidade de permitir métodos HTTP inseguros a serem executados nas rotas do controlador. Isso pode levar a possíveis ataques de Cross-Site Request Forgery (CSRF), especialmente se o desenvolvedor não estiver ciente dessa vulnerabilidade.

**Correção:** Para corrigir essa vulnerabilidade, devemos limitar os métodos HTTP permitidos nas rotas do controlador. Neste caso, podemos limitar as rotas `/links` e `/links-v2` para aceitarem apenas o método HTTP GET, pois eles são destinados a buscar informações (links).

```java
@RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
@RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
```


