### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +14,11 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABc
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** A vulnerabilidade em questão está relacionada ao fato de que os métodos HTTP não foram especificados nas anotações `@RequestMapping`. Isso significa que todos os tipos de métodos HTTP, incluindo opções inseguras, serão aceitos pelo controlador. Para garantir a segurança, devemos especificar os métodos HTTP permitidos, como `GET` ou `POST`.

**Correção:** 
```java
@RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
@RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
```

