### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,12 +14,13 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
+  List<String> links(@RequestParam String url) throws IOException {
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
+
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
+  List<String> linksV2(@RequestParam String url) throws BadRequest {
     return LinkLister.getLinksV2(url);
   }
 }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABb
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** A vulnerabilidade mencionada diz respeito ao uso de HTTP methods inseguros e como eles podem ser explorados. No código fornecido, a aplicação permite o uso dos métodos HTTP padrão, como GET, POST, PUT, DELETE, etc. Esses métodos podem ser perigosos se forem permitidos em um contexto inseguro, dando à possibilidade de um ataque.

**Correção:** Uma forma de mitigar a vulnerabilidade é limitar os métodos HTTP permitidos para as rotas em questão `/links` e `/links-v2`. Neste caso, uma solução seria permitir apenas o método GET, já que as rotas estão retornando informações e não alterando o estado do servidor.

```java
@RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
```

```java
@RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
```


