### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +14,11 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABc
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** A vulnerabilidade em questão se refere ao fato de permitir métodos HTTP inseguros no código. Métodos inseguros como POST, PUT, DELETE e PATCH podem expor o servidor a ataques de modificação, exclusão ou criação de recursos indevida. Portanto, é importante garantir que apenas métodos seguros sejam permitidos quando a funcionalidade do endpoint não exige métodos inseguros.

**Correção:** Para corrigir a vulnerabilidade, é necessário limitar os métodos HTTP permitidos nos endpoints às opções seguras, como GET. Podemos fazer isso usando a anotação `@RequestMapping` com o atributo `method`:

```java
@RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
```

```java
@RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
```


