### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,12 +14,12 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
+  List<String> links(@RequestParam String url) throws IOException {
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
+  List<String> linksV2(@RequestParam String url) throws BadRequest {
     return LinkLister.getLinksV2(url);
   }
 }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABb
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Moderado

**Explicação:** A vulnerabilidade mencionada refere-se ao tratamento inadequado de métodos HTTP considerados seguros e inseguros em endpoints. Métodos HTTP como GET e HEAD são considerados seguros, pois não fazem alterações no estado dos recursos no servidor. Por outro lado, métodos como POST, PUT, DELETE e PATCH são considerados como inseguros, pois podem modificar o estado dos recursos no servidor.

Neste caso, os endpoints "/links" e "links-v2" não definem o método HTTP que pode ser usado para acessá-los. Isso pode deixar brechas de segurança e permitir que atacantes executem métodos HTTP inadequados nos endpoints. É importante limitar e controlar quais métodos HTTP são autorizados para cada endpoint, a fim de garantir uma segurança adequada.

**Correção:** Adicione o atributo `method` nos mapeamentos de solicitações de ambos os endpoints, especificando que somente o método HTTP GET seja permitido:

```java
@RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
```

```java
@RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
```

