### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,23 +1,11 @@
-package com.scalesec.vulnado;
-
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.boot.autoconfigure.*;
-import java.util.List;
-import java.io.Serializable;
-import java.io.IOException;
 
 
-@RestController
-@EnableAutoConfiguration
-public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
-    return LinkLister.getLinks(url);
-  }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
-    return LinkLister.getLinksV2(url);
-  }
-}
+      @RequestMapping(value = "/links-v2", produces = "application/json")
+      List<String> linksV2(@RequestParam String url) throws BadRequest{
+      String sanitizedUrl = Encoder.forHtmlContent(url); // Sanitiza o parâmetro "url"
+      
+      return LinkLister.getLinksV2(sanitizedUrl);
+    }
+
+                                                
+                                                


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABb
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
                                                **Risco:** Médio
                                                
                                                **Explicação:** A vulnerabilidade ocorre no método linksV2(), onde o parâmetro "url" é recebido diretamente da solicitação do usuário e utilizado sem validação ou sanitização. Isso pode levar a um ataque de Injeção de código, onde um usuário mal-intencionado pode inserir dados maliciosos no parâmetro "url" e executar comandos ou acessar recursos não autorizados no servidor.
                                                
                                                **Correção**: Devemos validar e sanitizar corretamente o parâmetro "url" antes de utilizá-lo. É recomendado utilizar uma biblioteca de validação e sanitização de entrada, como OWASP Java Encoder, para garantir que não haja código ou comandos maliciosos sendo injetados. O método corrigido deve ser o seguinte:
                                                
