### PR TITLE
Correção: Make sure that this user-controlled command argument doesn't lead to unwanted behavior.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Cowsay.java
+++ b/src/main/java/com/scalesec/vulnado/Cowsay.java
@@ -1,3 +1,6 @@
+
+Code:
+
 package com.scalesec.vulnado;
 
 import java.io.BufferedReader;
@@ -6,9 +9,7 @@ import java.io.InputStreamReader;
 public class Cowsay {
   public static String run(String input) {
     ProcessBuilder processBuilder = new ProcessBuilder();
-    String cmd = "/usr/games/cowsay '" + input + "'";
-    System.out.println(cmd);
-    processBuilder.command("bash", "-c", cmd);
+    processBuilder.command("/usr/games/cowsay",input);
 
     StringBuilder output = new StringBuilder();
 


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCOcRw9aYd46TEDemP
- Arquivo: src/main/java/com/scalesec/vulnado/Cowsay.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** High

**Explicação:** This code has a Command Injection vulnerability. This vulnerability occurs when the application allows user input to be embedded in command-line instructions that are passed to the system shell. In this case, the user input is passed directly to the 'cowsay' command. An attacker may exploit this flaw by sending a string that contains shell meta-characters, effectively allowing arbitrary command execution in the host.

**Correção:** The fix is to only accept the necessary input and don’t run this directly using exec or ProcessBuilder or similar. Instead, provide each part of the command as a separate string in an array.

In the Java ProcessBuilder, commands are entered as an array of strings:

```java
processBuilder.command("/usr/games/cowsay",input);
```

This ensures that input will be treated as a single argument and not be able to manipulate the command-line.

Here is an amended version of the code:

```java
package com.scalesec.vulnado;

import java.io.BufferedReader;
import java.io.InputStreamReader;

public class Cowsay {
  public static String run(String input) {
    ProcessBuilder processBuilder = new ProcessBuilder();
    processBuilder.command("/usr/games/cowsay",input);

    StringBuilder output = new StringBuilder();

    try {
      Process process = processBuilder.start();
      BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));

      String line;
      while ((line = reader.readLine()) != null) {
        output.append(line + "\n");
      }
    } catch (Exception e) {
      e.printStackTrace();
    }
    return output.toString();
  }
}
```

