### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,6 @@
+
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -8,16 +11,18 @@ import java.util.List;
 import java.io.Serializable;
 import java.io.IOException;
 
-
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
+
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
+  public List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
+
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
+  public List<String> linksV2(@RequestParam String url) throws IOException{
     return LinkLister.getLinksV2(url);
   }
+  
 }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABc
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*

**Risco:** Alto

**Explicação:** O código em questão permite fazer solicitações HTTP tanto seguras quanto inseguras. Isso torna a aplicação suscetível a muitos riscos de segurança, tais como Man-in-the-Middle Attacks, Cross-Site Scripting e Injection Attacks. Permitir tanto métodos HTTP seguros quanto inseguros essencialmente significa que quaisquer restrições de segurança colocadas pelos métodos seguros são completamente ignoradas pela permissão de métodos inseguros.

**Correção:** 
A maneira mais eficaz de corrigir isso é remover a permissão para métodos HTTP inseguros. Em alguns casos, isso não é viável e, portanto, outras medidas de segurança precisam ser empregadas.

Embora a correção exata dependa da sua aplicação específica, uma possível correção pode ser algo como:

```java
import org.springframework.http.HttpMethod;
@RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
  List<String> links(@RequestParam String url) throws IOException{
    return LinkLister.getLinks(url);
  }
```
Aqui, estamos especificando que apenas solicitações `GET` são permitidas para o endpoint `"/links"`. As solicitações `POST`, `PUT`, `PATCH`, `DELETE` e outras seriam rejeitadas.

```java
@RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
  List<String> linksV2(@RequestParam String url) throws BadRequest{
    return LinkLister.getLinksV2(url);
  }
```


