### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+-------------------------
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -8,16 +10,15 @@ import java.util.List;
 import java.io.Serializable;
 import java.io.IOException;
 
-
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
-    return LinkLister.getLinks(url);
-  }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
-    return LinkLister.getLinksV2(url);
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
+List<String> links(@RequestParam String url) throws IOException{
+  return LinkLister.getLinks(url);
+}
+@RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
+List<String> linksV2(@RequestParam String url) throws BadRequest{
+  return LinkLister.getLinksV2(url);
   }
 }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABc
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** High

**Explicação:** O código em questão está vulnerável a um tipo de ataque chamado "HTTP Verb Tampering". Isso ocorre porque o método @RequestMapping não especifica o método HTTP, permitindo todos os métodos por padrão (GET, POST, PUT, DELETE, etc.). Isso pode levar a cenários imprevisíveis onde um invasor possa explorar endpoints que deveriam ser acessíveis apenas com um tipo específico de método HTTP. 

**Correção:** 

```java
@RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
List<String> links(@RequestParam String url) throws IOException{
  return LinkLister.getLinks(url);
}

@RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
List<String> linksV2(@RequestParam String url) throws BadRequest{
  return LinkLister.getLinksV2(url);
}
```

