### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -7,16 +9,17 @@ import org.springframework.boot.autoconfigure.*;
 import java.util.List;
 import java.io.Serializable;
 import java.io.IOException;
+import org.springframework.web.bind.annotation.GetMapping;
 
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @GetMapping(value = "/links", produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @GetMapping(value = "/links-v2", produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABb
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*

**Risco:** Alto 

**Explicação:** O código revela uma vulnerabilidade de segurança crítica chamada HTTP Verb Tampering. Basicamente, esse tipo de vulnerabilidade ocorre quando um invasor pode alterar ou usar um método HTTP diferente do previsto. Neste caso, pode ser permitido fazer um POST, PUT, DELETE ou outro request para as URLs "/links" e "/links-v2". Isso pode acarretar em diversas situações indesejadas, como modificações não autorizadas, exclusões ou mesmo inserções de dados no sistema.

Fazendo algumas premissas, se '/links' e '/links-v2' são meant para apenas extrair informações, elas devem permitir apenas métodos GET. Permitir outros tipos de método HTTP atinge o princípio de Segurança de mínima autorização, ou seja, dar acesso somente ao necessário.

**Correção:** 

Ao definir os controladores da API, melhor especificar o método HTTP que deseja permitir.

```java
@interface GetMapping
List<String> linksV2(@RequestParam String url) throws BadRequest{
  return LinkLister.getLinksV2(url);
}
```


