### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,6 @@
+-------------------------
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -8,16 +11,18 @@ import java.util.List;
 import java.io.Serializable;
 import java.io.IOException;
 
-
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  
+  @GetMapping(value = "/links", produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+
+  @GetMapping(value = "/links-v2", produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }
+  
 }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABb
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
**Risco:** Alto

**Explicação:** A vulnerabilidade mencionada está ligada à prática segura de permitir/desabilitar métodos HTTP de maneira adequada. No código fornecido, a anotação @RequestMapping é usada, que por padrão, permite todos os métodos HTTP como GET, POST, PUT, DELETE, etc. No entanto, não é seguro permitir todos os métodos HTTP para todas as rotas, pois isso pode abrir uma porta para ataques de vetores HTTP como Cross-Site Request Forgery (CSRF), ataques de método HTTP (onde o atacante pode tentar utilizar métodos não previstos pela aplicação) e outros.

**Correção:** Mude o @RequestMapping para o método específico que é necessário para sua funcionalidade, por exemplo, se você só precisa do método GET use @GetMapping. Isso limitará o acesso ao recurso a ser apenas via método GET, tornando os outros métodos HTTP inacessíveis para este recurso.

```java
@RestController
@EnableAutoConfiguration
public class LinksController {
  @GetMapping(value = "/links", produces = "application/json")
  List<String> links(@RequestParam String url) throws IOException{
    return LinkLister.getLinks(url);
  }
  @GetMapping(value = "/links-v2", produces = "application/json")
  List<String> linksV2(@RequestParam String url) throws BadRequest{
    return LinkLister.getLinksV2(url);
  }
}
```

