### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -8,16 +10,22 @@ import java.util.List;
 import java.io.Serializable;
 import java.io.IOException;
 
-
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
+  List<String> links(@RequestParam String url) throws IOException, HttpRequestMethodNotSupportedException{
+    if (!RequestMethod.GET.name().equals(request.getMethod())) {
+      throw new HttpRequestMethodNotSupportedException("(" + request.getMethod() + ")");
+    }
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
+
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
+  List<String> linksV2(@RequestParam String url) throws BadRequest, HttpRequestMethodNotSupportedException{
+    if (!RequestMethod.GET.name().equals(request.getMethod())) {
+      throw new HttpRequestMethodNotSupportedException("(" + request.getMethod() + ")");
+    }
     return LinkLister.getLinksV2(url);
   }
 }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABc
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Alto

**Explicação:** A vulnerabilidade é sobre controle de métodos HTTP no servidor. Os métodos HTTP incluem GET, POST, DELETE, PUT, entre outros. Cada método tem seu próprio propósito e deve ser usado corretamente. Por exemplo, GET é usado para obter informações do servidor, enquanto DELETE é usado para excluir informações.

Neste código, não há controle específico sobre quais métodos HTTP são permitidos a serem acessados. Isso significa que qualquer usuário pode usar qualquer método HTTP nesses pontos de extremidade. Um atacante mal intencionado poderia usar métodos HTTP inseguros para afetar adversamente o aplicativo. Eles poderiam usar o método DELETE para excluir informações ou o método PUT para alterar informações.

**Correção:** Para corrigir isso, devemos restringir quais métodos HTTP são permitidos. Podemos fazer isso usando a anotação @RequestMapping do Spring Boot, em combinação com o parâmetro `method`. Isso significa que apenas os métodos HTTP especificados podem acessar esses pontos extremos. Nesse caso, adicionaremos `method = RequestMethod.GET` para permitir apenas solicitações GET. Além disso, nós deveremos capturar a `HttpRequestMethodNotSupportedException` para retornar uma mensagem informativa ao usuario, já que agora bloquearemos metodos não permitidos.

```java
@RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
List<String> links(@RequestParam String url) throws IOException, HttpRequestMethodNotSupportedException{
  if (!RequestMethod.GET.name().equals(request.getMethod())) {
    throw new HttpRequestMethodNotSupportedException("(" + request.getMethod() + ")");
  }
  return LinkLister.getLinks(url);
}
@RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
List<String> linksV2(@RequestParam String url) throws BadRequest, HttpRequestMethodNotSupportedException{
  if (!RequestMethod.GET.name().equals(request.getMethod())) {
    throw new HttpRequestMethodNotSupportedException("(" + request.getMethod() + ")");
  }
  return LinkLister.getLinksV2(url);
}
```

