### PR TITLE
Correção: Make sure the "PATH" used to find this command includes only what you intend.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Cowsay.java
+++ b/src/main/java/com/scalesec/vulnado/Cowsay.java
@@ -1,3 +1,5 @@
+------------------
+
 package com.scalesec.vulnado;
 
 import java.io.BufferedReader;
@@ -6,9 +8,7 @@ import java.io.InputStreamReader;
 public class Cowsay {
   public static String run(String input) {
     ProcessBuilder processBuilder = new ProcessBuilder();
-    String cmd = "/usr/games/cowsay '" + input + "'";
-    System.out.println(cmd);
-    processBuilder.command("bash", "-c", cmd);
+    processBuilder.command("/usr/games/cowsay", input);
 
     StringBuilder output = new StringBuilder();
 


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfwm09McweT4LAA-
- Arquivo: src/main/java/com/scalesec/vulnado/Cowsay.java
- Severidade: LOW
*/Explicação:/*

**Risco:** Alto

**Explicação:** Esta vulnerabilidade se refere à injeção de comandos do shell. No código, vemos que a entrada do usuário (input) está sendo diretamente concatenada a um comando do shell sem nenhuma sanitização ou validação de entrada. Isso é perigoso porque um usuário mal-intencionado pode passar caracteres especiais ou instruções adicionais, levando à execução de comandos do (OS / Shell) a partir de sua entrada. 

Por exemplo, se um usuário insere algo como `myInput'; rm -rf / #` o comando que será executado seria: `/usr/games/cowsay '/usr/games/cowsay 'myInput'; rm -rf / #'`, o que exclui todos os arquivos do sistema se o programa estiver sendo executado com as permissões necessárias.

**Correção:** Para corrigir essa vulnerabilidade, trocaremos a chamada processBuilder.command() para aceitar argumentos diretos ao invés de concatenar a entrada do usuário ao comando. Dessa forma, a entrada do usuário será tratada como uma única string de argumento, e não como parte do comando shell a ser executado.

```java
...
processBuilder.command("/usr/games/cowsay", input);
...
```

