### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,12 +14,22 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+
+  UrlValidator urlValidator = new UrlValidator();
+
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
+    if(!urlValidator.isValid(url)){
+      throw new BadRequestException("Url fornecida inválida!");  
+    }
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
+    if(!urlValidator.isValid(url)){
+      throw new BadRequestException("Url fornecida inválida!");  
+    }
     return LinkLister.getLinksV2(url);
   }
 }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABb
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Alto

**Explicação:** No código fornecido, as rotas `"/links"` e `"/links-v2"` estão abertas para todos os métodos HTTP, como GET, POST, PUT, DELETE, PATCH etc., porque não especificamos qual método HTTP deve ser permitido. Isso pode ser explorado por um usuário mal-intencionado para realizar operações indesejadas, como POST ou DELETE, quando tais operações não são esperadas ou desejadas.

Além disso, o parâmetro url aceito pelas duas rotas não é validado para verificar a sua legitimidade. Isso pode levar a ataques de injeção de URL phishing fazendo chamadas com URLs maliciosas.

**Correção:**  Especificar qual método HTTP deve ser permitido no mapeamento de solicitação e adicionar validação de URL para validar a URL fornecida pelo cliente.

```java
@RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
```

```java
List<String> links(@RequestParam String url) throws IOException{
  if(!urlValidator.isValid(url)){
    throw new BadRequestException("Url fornecida inválida!");  
  }
  return LinkLister.getLinks(url);
}
```

