### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,23 +1,26 @@
+--
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
+
 import java.util.List;
 import java.io.Serializable;
 import java.io.IOException;
 
-
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json") 
+  List<String> links(@RequestParam String url) throws IOException {
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
+
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json") 
+  List<String> linksV2(@RequestParam String url) throws BadRequest {
     return LinkLister.getLinksV2(url);
   }
 }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABc
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** A vulnerabilidade encontrada no código é que ele está permitindo métodos HTTP inseguros. Todos os métodos HTTP como GET, POST, DELETE, PUT, etc. são permitidos aqui, mas nem todos são seguros. GET e POST são geralmente considerados seguros, enquanto DELETE e PUT representam um risco de alterar ou eliminar dados importantes. Além disso, alguns desses métodos podem ser usados em ataques de Cross-Site Request Forgery (CSRF).

Os métodos HTTP devem ser limitados e somente permitidos quando necessário. Quando se permite todos os métodos HTTP indistintamente, a aplicação fica exposta a potenciais problemas de segurança.

**Correção:** 

Podemos resolver essa vulnerabilidade limitando os métodos HTTP permitidos nas rotas de nossa aplicação, no caso específico dessas rotas, podemos restringir apenas o método GET, já que nenhuma alteração de dados está sendo realizada.

```java
@RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
@RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
```


