### PR TITLE
Correção: Make sure the "PATH" used to find this command includes only what you intend.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Cowsay.java
+++ b/src/main/java/com/scalesec/vulnado/Cowsay.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import java.io.BufferedReader;
@@ -6,9 +8,9 @@ import java.io.InputStreamReader;
 public class Cowsay {
   public static String run(String input) {
     ProcessBuilder processBuilder = new ProcessBuilder();
-    String cmd = "/usr/games/cowsay '" + input + "'";
-    System.out.println(cmd);
-    processBuilder.command("bash", "-c", cmd);
+    String[] cmd = { "/usr/games/cowsay", input };
+    System.out.println(String.join(" ", cmd));
+    processBuilder.command(cmd);
 
     StringBuilder output = new StringBuilder();
 
@@ -24,5 +26,5 @@ public class Cowsay {
       e.printStackTrace();
     }
     return output.toString();
-  }
+   }
 }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfwm09McweT4LAA-
- Arquivo: src/main/java/com/scalesec/vulnado/Cowsay.java
- Severidade: LOW
*/Explicação:/*  

**Risco:** Alto

**Explicação:** A vulnerabilidade aqui ocorre devido à injeção de comandos. Estamos aceitando a entrada do usuário e passando-a diretamente para um comando de shell sem qualquer forma de validação ou saneamento, isto é um risco muito alto. Alguém poderia simplesmente passar `'; rm -rf /'` como entrada e apagar todo o sistema de arquivos. Além disso, essa é uma prática muito ruim de codificação, pois estamos passando a entrada do usuário diretamente para a linha de comando. Isso nos deixa abertos a todos os tipos de ataques de injeção.

**Correção:** 
Devemos garantir que a entrada seja corretamente manipulada antes de ser usada em comandos de shell. Podemos usar um processo separado e passar a entrada como um argumento, e não como parte do comando. Isso evita que comandos adicionais sejam injetados. No entanto, a correção completa exigiria a reescrita desta função para evitar completamente a passagem de entrada do usuário para o comando de shell.

```java
String[] cmd = { "/usr/games/cowsay", input };
processBuilder.command(cmd);
```

