### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +14,12 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABb
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Alto

**Explicação:** O código vulnerável permite métodos HTTP seguros e inseguros para obter links de uma URL específica. Isso pode potencialmente permitir que um invasor envie solicitações HTTP inseguras, por exemplo, através do método DELETE, que pode ter efeitos deletérios se o servidor estiver mal configurado ou se o código tiver outras vulnerabilidades.

**Correção:** Para corrigir isso, devemos especificar quais métodos HTTP são permitidos. Considerando que estamos apenas obtendo dados, devemos permitir apenas o método GET.

```java
  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
  List<String> links(@RequestParam String url) throws IOException{
    return LinkLister.getLinks(url);
  }

  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
  List<String> linksV2(@RequestParam String url) throws BadRequest{
    return LinkLister.getLinksV2(url);
  }
```
Incluí `"method = RequestMethod.GET"` para ambos os métodos, o que significa que apenas as solicitações GET são permitidas para essas rotas.


