### PR TITLE
Correção: Make sure that enabling CORS is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -1,3 +1,6 @@
+------------------------
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.http.HttpStatus;
@@ -13,20 +16,20 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "https://gft.com")
   @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "https://gft.com")
   @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
     return Comment.create(input.username, input.body);
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "https://gft.com")
   @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
@@ -51,3 +54,4 @@ class ServerError extends RuntimeException {
     super(exception);
   }
 }
+


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfw609McweT4LAB0
- Arquivo: src/main/java/com/scalesec/vulnado/CommentsController.java
- Severidade: LOW
*/Explicação:/*

**Risco:** Alto

**Explicação:** CORS (Cross Origin Resource Sharing) é uma funcionalidade que permite a uma aplicação web fazer requisições para um domínio diferente do que o que foi originado. No código acima, o cabeçalho `@CrossOrigin(origins = "*")` permite que qualquer domínio possa fazer uma requisição. Isso faz com que a aplicação esteja aberta para o que é conhecido como ataque de Cross-Site Request Forgery (CSRF). Em um ataque CSRF, um invasor engana a vítima para fazer uma requisição maliciosa para um site ao qual a vítima está autenticada. 

**Correção:** Remover ou substituir `@CrossOrigin(origins = "*")` com o domínio que deveria ter permissão para fazer requisições. Se só tivermos um domínio que deva ter permissão para fazer requisições, podemos substituir o `"*"` por esse domínio. Isso irá assegurar que só requisições desse domínio serão aceitas.

```java
  @CrossOrigin(origins = "https://gft.com")
  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
  List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
    User.assertAuth(secret, token);
    return Comment.fetch_all();
  }

  @CrossOrigin(origins = "https://gft.com")
  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
  Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
    return Comment.create(input.username, input.body);
  }

  @CrossOrigin(origins = "https://gft.com")
  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
  Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
    return Comment.delete(id);
  }
```

