### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,7 @@
+
+Atualização completa do código Java:
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +16,11 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABb
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*
**Risco:** Médio

**Explicação:** O código em questão permite que as solicitações HTTP usem qualquer método para obter recursos precisamente a partir do endpoint `/links` e `/links-v2`. Isso pode permitir a um atacante usar métodos HTTP como PUT e DELETE, o que pode levar a algum comportamento indesejado.

É uma prática recomendada especificar somente os métodos HTTP permitidos pelos seus endpoints. Portanto, as solicitações HTTP deveriam ter permissões restritas aos métodos seguros como GET, POST, HEAD, etc.

**Correção:**
Aqui está o trecho de código corrigido: 

```java
@RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
@RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
```


