### PR TITLE
Correção: Make sure this debug feature is deactivated before delivering the code in production.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Comment.java
+++ b/src/main/java/com/scalesec/vulnado/Comment.java
@@ -1,11 +1,16 @@
+-----------------------------
+*Apenas o Código completo com a correção:*
+
+
 package com.scalesec.vulnado;
 
-import org.apache.catalina.Server;
 import java.sql.*;
 import java.util.Date;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class Comment {
   public String id, username, body;
@@ -52,8 +57,7 @@ public class Comment {
       }
       cxn.close();
     } catch (Exception e) {
-      e.printStackTrace();
-      System.err.println(e.getClass().getName()+": "+e.getMessage());
+      Logger.getLogger(Comment.class.getName()).log(Level.SEVERE, null, e);
     } finally {
       return comments;
     }
@@ -67,7 +71,7 @@ public class Comment {
       pStatement.setString(1, id);
       return 1 == pStatement.executeUpdate();
     } catch(Exception e) {
-      e.printStackTrace();
+      Logger.getLogger(Comment.class.getName()).log(Level.SEVERE, null, e);
     } finally {
       return false;
     }
@@ -84,3 +88,5 @@ public class Comment {
     return 1 == pStatement.executeUpdate();
   }
 }
+
+Por favor, lembre-se que é importante usar a correção mais apropriada para o ambiente onde você está. Na maioria dos casos, é uma boa ideia ter um balanceamento entre segurança e usabilidade quando se trata de debugs.


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfwt09McweT4LABa
- Arquivo: src/main/java/com/scalesec/vulnado/Comment.java
- Severidade: LOW
*/Explicação:/*
**Risco:** Alto

**Explicação:** O código atual tem um recurso de debug ativado em tempo de execução. Isto pode ser uma grande vulnerabilidade, uma vez que permitirá a um invasor ter um entendimento detalhado do funcionamento interno do seu sistema, se eles tiverem acesso a esses logs de depuração. Ativar o debug em produção expõe muitos detalhes que normalmente não devem ser visíveis, incluindo detalhes do servidor, parâmetros de requisições, detalhes do banco de dados, stack trace de erros, etc.

**Correção:**

Em seu catch, troque a função `e.printStackTrace();` por logs controlados, como esta:
```java
catch (Exception e) {
  Logger.getLogger(Comment.class.getName()).log(Level.SEVERE, null, e);
}
```
Essa mudança garante que os detalhes do erro sejam exibidos apenas nos logs do servidor e não sejam exibidos para o cliente. Você também precisará importar o Logger e o Level na parte superior de seu arquivo.
```java
import java.util.logging.Level;
import java.util.logging.Logger;
```

Lembre-se, em um ambiente de produção, tenha certeza que os logs do servidor estão seguros e somente pessoas autorizadas tenham acesso a eles.


