### PR TITLE
Correção: Make sure this debug feature is deactivated before delivering the code in production.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Comment.java
+++ b/src/main/java/com/scalesec/vulnado/Comment.java
@@ -1,3 +1,5 @@
+
+ java
 package com.scalesec.vulnado;
 
 import org.apache.catalina.Server;
@@ -6,10 +8,13 @@ import java.util.Date;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.UUID;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class Comment {
   public String id, username, body;
   public Timestamp created_on;
+  private static final Logger logger = Logger.getLogger(Comment.class.getName());
 
   public Comment(String id, String username, String body, Timestamp created_on) {
     this.id = id;
@@ -35,7 +40,7 @@ public class Comment {
 
   public static List<Comment> fetch_all() {
     Statement stmt = null;
-    List<Comment> comments = new ArrayList();
+    List<Comment> comments = new ArrayList<>();
     try {
       Connection cxn = Postgres.connection();
       stmt = cxn.createStatement();
@@ -52,7 +57,9 @@ public class Comment {
       }
       cxn.close();
     } catch (Exception e) {
-      e.printStackTrace();
+      //e.printStackTrace();
+      // Não imprima detalhes técnicos para o usuário.
+      logger.log(Level.SEVERE, e.getMessage(), e);
       System.err.println(e.getClass().getName()+": "+e.getMessage());
     } finally {
       return comments;
@@ -67,7 +74,9 @@ public class Comment {
       pStatement.setString(1, id);
       return 1 == pStatement.executeUpdate();
     } catch(Exception e) {
-      e.printStackTrace();
+      //e.printStackTrace();
+      // Não imprima detalhes técnicos para o usuário.
+      logger.log(Level.SEVERE, e.getMessage(), e);
     } finally {
       return false;
     }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfwt09McweT4LABa
- Arquivo: src/main/java/com/scalesec/vulnado/Comment.java
- Severidade: LOW
*/Explicação:/*
**Risco:** Médio

**Explicação:** O recurso de depuração (debug) pode expor detalhes técnicos sobre o aplicativo, que por sua vez podem ser utilizados por um invasor para explorar a aplicação de forma mais eficiente. Mesmo que esse recurso seja útil durante a fase de desenvolvimento e teste, ele deve ser desativado antes de o aplicativo entrar em produção.

**Correção:** Não vejo um recurso de depuração explícito nesse código. No entanto, as pilhas de traços (stack traces) são frequentemente usadas para depuração e seu código está exibindo-as nos catch blocks das funções `fetch_all()` e `delete(String id)`. Recomendo não imprimir as pilhas de traços a menos que esteja em um ambiente de desenvolvimento. No ambiente de produção, registre os erros de uma maneira segura que possa ajudar a diagnosticar o problema sem revelar detalhes técnicos sobre sua aplicação.

``` java
try {
  // ...
} catch (Exception e) {
  // e.printStackTrace();
  // Não imprima detalhes técnicos para o usuário.
  Logger logger = Logger.getLogger(Comment.class.getName());
  logger.log(Level.SEVERE, e.getMessage(), e);
  // ...
}
```

