### PR TITLE
Correção: Make sure that enabling CORS is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -1,3 +1,7 @@
+---------
+Abaixo segue a versão corrigida do código, considerando que os domínios https://gft.com e http://localhost:8080 são confiáveis.
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.http.HttpStatus;
@@ -13,20 +17,20 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "https://gft.com,http://localhost:8080")
   @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "https://gft.com,http://localhost:8080")
   @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
     return Comment.create(input.username, input.body);
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "https://gft.com,http://localhost:8080")
   @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
@@ -51,3 +55,5 @@ class ServerError extends RuntimeException {
     super(exception);
   }
 }
+
+Esteja ciente de que você precisa configurar adequadamente CORS em produção para restringir o acesso de acordo com a política de segurança de sua aplicação.


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfw609McweT4LAB0
- Arquivo: src/main/java/com/scalesec/vulnado/CommentsController.java
- Severidade: LOW
*/Explicação/*

**Risco:** Alto

**Explicação:** A vulnerabilidade aqui é que o CORS (Cross-Origin Resource Sharing) está habilitado de forma bastante liberal. A anotação @CrossOrigin(origins = "*") em todos os métodos de controller permite que qualquer origem (ou seja, site) faça solicitações para essa API. Isso pode ser explorado por um atacante para fazer solicitações indesejadas, levar a vazamento de dados, etc. A origem "* " deve ser substituída por um domínio específico/dominios de confiança ao qual você deseja permitir solicitações de origem cruzada e listá-los separados por uma vírgula.

**Correção:** 

```java
// Aqui é feita a alteração nos @CrossOrigin
@CrossOrigin(origins = "https://gft.com,http://localhost:8080") 
```


