### PR TITLE
Correção: Make sure the "PATH" used to find this command includes only what you intend.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Cowsay.java
+++ b/src/main/java/com/scalesec/vulnado/Cowsay.java
@@ -1,28 +1,40 @@
+
+
+
 package com.scalesec.vulnado;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.util.Arrays;
 
 public class Cowsay {
-  public static String run(String input) {
-    ProcessBuilder processBuilder = new ProcessBuilder();
-    String cmd = "/usr/games/cowsay '" + input + "'";
-    System.out.println(cmd);
-    processBuilder.command("bash", "-c", cmd);
 
-    StringBuilder output = new StringBuilder();
+public static String run(String input) {
 
-    try {
-      Process process = processBuilder.start();
-      BufferedReader reader = new BufferedReader(new InputStreamReader(process.getInputStream()));
+  ProcessBuilder processBuilder = new ProcessBuilder();
+  processBuilder.command(Arrays.asList("/usr/games/cowsay", input));
 
-      String line;
-      while ((line = reader.readLine()) != null) {
-        output.append(line + "\n");
-      }
-    } catch (Exception e) {
-      e.printStackTrace();
+  StringBuilder output = new StringBuilder();
+
+  try {
+
+    Process process = processBuilder.start();
+    BufferedReader reader = 
+        new BufferedReader(new InputStreamReader(process.getInputStream()));
+
+    String line;
+
+    while ((line = reader.readLine()) != null) {
+
+      output.append(line + "\n");
     }
-    return output.toString();
+
+  } catch (Exception e) {
+
+    e.printStackTrace();
   }
+
+  return output.toString();
+ }
 }
+


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfwm09McweT4LAA-
- Arquivo: src/main/java/com/scalesec/vulnado/Cowsay.java
- Severidade: LOW
*/Explicação:/*

**Risco:** Alto

**Explicação:** O problema aqui reside principalmente na linha onde a variável `cmd` é definida. É uma prática de segurança importante sempre validar e escapar corretamente a entrada do usuário antes de usá-la. Neste caso específico, a entrada do usuário está sendo diretamente concatenada sem qualquer validação a um comando de sistema, isto é, alguém poderia facilmente injetar um comando malicioso e o sistema iria executá-lo sem levantar qualquer sinal de alerta. Isso é conhecido como uma vulnerabilidade de injeção de comando do sistema operacional (OS Command Injection). 

**Correção:** A forma como você geralmente resolveria isso em Java é utilizando o método `Arrays.asList()` da classe `ProcessBuilder` que aceita um varargs de `String`, assim não precisando concatenar a entrada do usuário diretamente ao comando que você pretende executar.

```java
import java.util.Arrays;


processBuilder.command(Arrays.asList("/usr/games/cowsay", input));
```


