### PR TITLE
Correção: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,3 +1,5 @@
+
+
 package com.scalesec.vulnado;
 
 import org.springframework.boot.*;
@@ -12,11 +14,11 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
Correção para a vulnerabilidade encontrada:

- Vulnerabilidade: AYkCLfww09McweT4LABc
- Arquivo: src/main/java/com/scalesec/vulnado/LinksController.java
- Severidade: HIGH
*/Explicação:/*

**Risco:** Alto

**Explicação:** A vulnerabilidade diz respeito ao uso inseguro de métodos HTTP em uma aplicação. A aplicação atualmente permite que qualquer tipo de método HTTP seja utilizado nas rotas "/links" e "/links-v2". Porém, como a aplicação não faz nenhum tipo de tratamento, métodos perigosos como DELETE ou PUT poderiam ser usados para afetar a integridade da aplicação.

A melhor prática seria permitir apenas os métodos específicos que a aplicação realmente precisa e que são seguros. Nesse caso, como as rotas estão sendo utilizadas para retornar uma lista de links, o melhor método a ser usado seria o GET. Permitir qualquer outro método aumenta a superfície de ataque para invasões.

**Correção:** 
```java
@RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
List<String> links(@RequestParam String url) throws IOException{
  return LinkLister.getLinks(url);
}
@RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
List<String> linksV2(@RequestParam String url) throws BadRequest{
  return LinkLister.getLinksV2(url);
}
```

