### PR TITLE
Correction: Make sure that this user-controlled command argument doesn't lead to unwanted behavior.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -7,17 +7,36 @@ import org.springframework.boot.autoconfigure.*;
 import java.util.List;
 import java.io.Serializable;
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
 
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
+
   @RequestMapping(value = "/links", produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
+    if(!isValidURL(url)) {
+      throw new BadRequestException("Invalid URL");
+    }
     return LinkLister.getLinks(url);
   }
+
   @RequestMapping(value = "/links-v2", produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
+    if(!isValidURL(url)) {
+      throw new BadRequestException("Invalid URL");
+    }
     return LinkLister.getLinksV2(url);
+  }
+
+  private boolean isValidURL(String url) {
+    try {
+      new URL(url);
+      return true;
+    } catch (MalformedURLException ex) {
+      return false;
+    }
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AImpact Bot para o b5de0c12056e6f2667e9f4ce70c2a15a0f321efc
                                             
**Descrição:** O Pull Request 540 intitulado 'Correction: Make sure that this user-controlled command argument doesn't lead to unwanted behavior' introduz uma correção para validar a URL passada como argumento nas funções `links` e `linksV2` para evitar comportamentos indesejados. 

                                             
**Sumario:** 

- Arquivo modificado: `src/main/java/com/scalesec/vulnado/LinksController.java`
  - Adicionadas importações para `java.net.MalformedURLException` e `java.net.URL`.
  - Inserida uma verificação de URL válida na função `links` e `linksV2` usando a função `isValidURL`. Caso a URL não seja válida, uma exceção `BadRequestException` é lançada.
  - A função `isValidURL` foi adicionada. Ela tenta criar um novo objeto `URL` com a URL fornecida. Se isso falhar, uma exceção `MalformedURLException` é capturada e `false` é retornado, indicando que a URL não é válida.

**Recomendações:** 

- Recomendo que o revisor verifique a implementação da função `isValidURL` para garantir que ela efetivamente valida corretamente a URL.
- É aconselhável testar a função com várias entradas diferentes para garantir que ela se comporta como esperado.
- Por fim, verifique se `BadRequestException` é apropriado para este caso, ou se outro tipo de exceção seria mais apropriado.