### PR TITLE
Correction: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CowController.java
+++ b/src/main/java/com/scalesec/vulnado/CowController.java
@@ -8,7 +8,7 @@ import java.io.Serializable;
 @RestController
 @EnableAutoConfiguration
 public class CowController {
-    @RequestMapping(value = "/cowsay")
+    @RequestMapping(value = "/cowsay", method = RequestMethod.GET)
     String cowsay(@RequestParam(defaultValue = "I love Linux!") String input) {
         return Cowsay.run(input);
     }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AImpact Bot para o 7101122a3f9b46237d055da4b3460dc42239493b

**Descrição:** Esta é uma correção para garantir que métodos HTTP seguros e inseguros são permitidos de forma segura. Antes da alteração, o mapeamento da URL "/cowsay" estava aceitando qualquer método HTTP. Agora, com a alteração, apenas o método GET é permitido.

**Sumário:**
- src/main/java/com/scalesec/vulnado/CowController.java (modificado) - O mapeamento para a URL "/cowsay" foi alterado para permitir apenas o método GET, e não qualquer método.

**Recomendações:** Verifique se a alteração se aplica corretamente ao mapeamento da URL. Teste a aplicação para garantir que apenas o método GET é aceito para a URL "/cowsay". Outros métodos HTTP devem retornar um erro. Além disso, é aconselhável adicionar uma nova linha ao final do arquivo para seguir as melhores práticas de codificação.