### PR TITLE
[GFTCodeFix]: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -8,15 +8,14 @@ import java.util.List;
 import java.io.Serializable;
 import java.io.IOException;
 
-
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AImpact Bot para o 4fd4ce88b1a3d01a4fe93cd3a2013d8d082b4070

**Descrição:** 
O pull request 550 intitulado '[GFTCodeFix]: Make sure allowing safe and unsafe HTTP methods is safe here.' tem como objetivo especificar os métodos HTTP permitidos para as rotas "/links" e "/links-v2" no controlador 'LinksController.java'. Os métodos foram modificados para aceitar apenas o método GET.

**Sumario:** 
- Arquivo modificado: src/main/java/com/scalesec/vulnado/LinksController.java 
  - A rota "/links" foi alterada para permitir apenas solicitações GET.
  - A rota "/links-v2" foi alterada para permitir apenas solicitações GET. 
  - Removido espaço em branco extra.

**Recomendações:** 
- É importante testar essas rotas novamente para garantir que elas estejam funcionando corretamente com o método GET e que não estejam aceitando outros métodos HTTP.
- Tenha certeza que a remoção do espaço em branco extra não afeta a leitura e a estrutura do código.

**Explicação de Vulnerabilidades:** 
- A especificação do método HTTP para as rotas é uma boa prática de segurança, pois limita as ações que podem ser realizadas. Anteriormente, ao não especificar o método, qualquer método HTTP poderia ser usado, o que poderia levar a comportamentos não intencionais ou inseguros. Agora, apenas o método GET é permitido, o que é uma melhoria significativa para a segurança. 

Por favor, lembre-se de seguir essas práticas de segurança ao adicionar novas rotas no futuro.