### PR TITLE
[GFTCodeFix]: Make sure using a dynamically formatted SQL query is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,7 +1,7 @@
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.JwtParser;
@@ -37,16 +37,19 @@ public class User {
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
+    PreparedStatement stmt = null;
+    ResultSet rs = null;
     User user = null;
     try {
       Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
       System.out.println("Opened database successfully");
 
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      String query = "select * from users where username = ? limit 1";
+      stmt = cxn.prepareStatement(query);
+      stmt.setString(1, un);
+      System.out.println(stmt.toString());
+      rs = stmt.executeQuery();
+
       if (rs.next()) {
         String user_id = rs.getString("user_id");
         String username = rs.getString("username");
@@ -58,6 +61,12 @@ public class User {
       e.printStackTrace();
       System.err.println(e.getClass().getName()+": "+e.getMessage());
     } finally {
+      try {
+        if (stmt != null) { stmt.close(); }
+        if (rs != null) { rs.close(); }
+      } catch (Exception e) {
+        e.printStackTrace();
+      }
       return user;
     }
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AImpact Bot para o 753197892a1f82ae8427f483d89bbcfc9cc9bdce

**Descrição:** Este pull request é uma correção de segurança que atualiza a maneira como as consultas SQL são formatadas e executadas no método `fetch` da classe `User`. O código agora usa `PreparedStatement` em vez de `Statement`, o que ajuda a prevenir ataques de injeção SQL. Além disso, os recursos de banco de dados são explicitamente fechados no bloco `finally` para evitar vazamentos de recursos.

**Sumario:**
- ```src/main/java/com/scalesec/vulnado/User.java (modificado)``` - A consulta SQL foi alterada para usar `PreparedStatement` em vez de `Statement`. Isso ajuda a prevenir ataques de injeção SQL. Além disso, os recursos de banco de dados `stmt` e `rs` são agora explicitamente fechados no bloco `finally`.

**Violação de Regras de Qualidade:**
- Nenhuma

**Violação de Regras de Segurança:**
- Nenhuma

**Violação de Regras de Nomenclatura:**
- Nenhuma

**Recomendações:** Recomendo verificar a aplicação de `PreparedStatement` em todas as outras consultas SQL no projeto para garantir a segurança contra ataques de injeção SQL. Além disso, sugeriria a adição de logs de erro mais descritivos em caso de exceções.