### PR TITLE
[GFTCodeFix]: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -12,11 +12,11 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AImpact Bot para o 9266860588c44497ff1e43882f3af9e5af0eac92

**Descrição:** Este Pull Request foi feito para garantir que apenas métodos HTTP seguros sejam permitidos. As alterações foram feitas nos métodos `links` e `linksV2` na classe `LinksController`.

**Sumario:**  
-  ```src/main/java/com/scalesec/vulnado/LinksController.java (modificado)``` - Os métodos `links` e `linksV2` foram alterados para aceitar apenas requisições GET. Anteriormente, todos os tipos de métodos HTTP eram permitidos.

**Violação de Regras de Qualidade:**  
-  Nenhuma violação foi encontrada.

**Violação de Regras de Segurança:**  
-  Nenhuma violação foi encontrada. 

**Violação de Regras de Nomenclatura:**  
-  Nenhuma violação foi encontrada.

**Recomendações:** As alterações parecem estar em conformidade com as regras de qualidade, segurança e nomenclatura. No entanto, recomenda-se testar a funcionalidade para garantir que apenas métodos GET sejam permitidos nos endpoints alterados.