### PR TITLE
[GFTCodeFix]: Make sure that enabling CORS is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,20 +13,22 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
+  private static final String trustedOrigins = "http://trustedorigin.com"; // incluir aqui os domínios confiáveis
+
+  @CrossOrigin(origins = trustedOrigins)
   @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = trustedOrigins)
   @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
     return Comment.create(input.username, input.body);
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = trustedOrigins)
   @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AImpact Bot para o 86e98c69c07a1e622b75086187348dc14fd4a16b

**Descrição:** Este Pull Request faz uma modificação de segurança importante no controle de Comentários da aplicação. Antes, o anotador `@CrossOrigin` estava configurado para aceitar qualquer origem (`"*"`). Agora, ele foi alterado para aceitar apenas origens confiáveis, definidas na variável `trustedOrigins`. Isso aumenta a segurança contra ataques CSRF.

**Sumário:**  
-  ```src/main/java/com/scalesec/vulnado/CommentsController.java (modificado)``` - Substituição do wildcard (`"*"`) no anotador `@CrossOrigin` por uma variável contendo domínios confiáveis (`trustedOrigins`). 

**Violação de Regras de Qualidade:** : 
- Não foram identificadas violações das regras de qualidade no código modificado.

**Violação de Regras de Segurança:** : 
- Não foram identificadas violações das regras de segurança no código modificado.

**Violação de Regras de Nomenclatura:** : 
- Não foram identificadas violações das regras de nomenclatura no código modificado.

**Recomendações:** 
- Embora a modificação tenha melhorado a segurança contra ataques CSRF, a variável `trustedOrigins` está hardcoded no código. Seria mais seguro e flexível se essa lista de domínios confiáveis fosse configurada através de variáveis de ambiente ou arquivos de configuração externos. 
- Além disso, é importante ter cuidado ao adicionar novos domínios à lista de origens confiáveis, para evitar a inclusão de domínios mal-intencionados.
- Por fim, é aconselhável adicionar mais testes para garantir que apenas as origens confiáveis possam fazer solicitações CORS para esses pontos de extremidade da API.