### PR TITLE
[GFTCodeFix]: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -8,16 +8,17 @@ import java.util.List;
 import java.io.Serializable;
 import java.io.IOException;
 
-
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
+  
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
+  public List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
+  
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
+  public List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AImpact Bot para o 3f93483f118633936d7f5a5a2237ed2fc909d958 \n
**Descrição:** Neste pull request, as mudanças se concentram na forma como os métodos HTTP são tratados no `LinksController.java`. Antes, qualquer método HTTP poderia ser usado, agora, apenas o método GET é permitido, aumentando a segurança do código. A visibilidade do método também foi alterada para público.
\n 
**Sumario:**  \n 
-  ```src/main/java/com/scalesec/vulnado/LinksController.java (modificado)``` - Os endpoints "/links" e "/links-v2" foram alterados para permitir apenas solicitações GET e a visibilidade do método foi alterada para público. Além disso, foi removido um espaço em branco desnecessário no início do arquivo. \n
\n
**Violação de Regras de Qualidade:** : \n 
-  Nenhuma violação foi encontrada \n            
\n
**Violação de Regras de Segurança:** : \n 
-  Nenhuma violação foi encontrada \n            
\n
**Violação de Regras de Nomenclatura:** : \n 
-  Nenhuma violação foi encontrada \n            
\n
**Recomendações:** : Recomendaria testar os endpoints alterados para garantir que apenas solicitações GET são aceitas agora. Além disso, seria bom verificar se a visibilidade pública do método não tem nenhum efeito colateral indesejado.