### PR TITLE
[GFTCodeFix]: Make sure allowing safe and unsafe HTTP methods is safe here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -8,16 +8,17 @@ import java.util.List;
 import java.io.Serializable;
 import java.io.IOException;
 
-
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
+  
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
+  public List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
+  
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
+  public List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AImpact Bot para o b43a448b8eb7095363d75a2d15ba29d048b0dcc4

**Descrição:** 
Neste pull request, o método de requisição HTTP foi especificado para duas rotas no controlador de Links. Anteriormente, não havia um método HTTP especificado, tornando todas as rotas vulneráveis a solicitações de qualquer tipo de método HTTP. Agora, apenas solicitações GET são permitidas.

**Sumario:**  
-  ```src/main/java/com/scalesec/vulnado/LinksController.java (modificado)``` - Os métodos de requisição HTTP foram especificados para as rotas "/links" e "/links-v2", permitindo apenas solicitações GET. A visibilidade do método também foi alterada para público.

**Violação de Regras de Qualidade:** : 
- Não foram encontradas violações das regras de qualidade.

**Violação de Regras de Segurança:** : 
- Não foram encontradas violações das regras de segurança.

**Violação de Regras de Nomenclatura:** : 
- Não foram encontradas violações das regras de nomenclatura.

**Recomendações:** 
- Verifique se a alteração não quebra nenhuma funcionalidade existente.
- Teste as rotas "/links" e "/links-v2" com outros métodos HTTP para garantir que apenas GET é permitido.
- Garanta que a visibilidade pública dos métodos não introduza novas vulnerabilidades.