### PR TITLE
[GFTCodeFix]: Make sure this debug feature is deactivated before delivering the code in production.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,7 +1,7 @@
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.JwtParser;
@@ -37,16 +37,14 @@ public class User {
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
+    PreparedStatement stmt = null;
     User user = null;
     try {
       Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
-      System.out.println("Opened database successfully");
-
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      String query = "select * from users where username = ? limit 1";
+      stmt = cxn.prepareStatement(query);
+      stmt.setString(1, un);
+      ResultSet rs = stmt.executeQuery();
       if (rs.next()) {
         String user_id = rs.getString("user_id");
         String username = rs.getString("username");


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AImpact Bot para o d397d6145d03dbdea74e2946b9c26c810b0f247a

**Descrição:** Este Pull Request tem como objetivo corrigir uma vulnerabilidade de injeção de SQL no método `fetch` da classe `User`. A alteração consiste na substituição do uso de `Statement` por `PreparedStatement`, evitando assim a inserção de parâmetros diretamente na string SQL e removendo a possibilidade de injeção de SQL.

**Sumario:**  
 -  ```src/main/java/com/scalesec/vulnado/User.java (modificado)``` - Substituição do uso de `Statement` por `PreparedStatement` para evitar injeção de SQL. Também foi removida a impressão de debug que exibia a query SQL.

**Violação de Regras de Qualidade:** : 
 -  Não foram encontradas violações nas regras de qualidade.

**Violação de Regras de Segurança:** : 
 -  Antes da alteração, o código violava a regra de "sqlInjection" devido ao uso de `Statement`. Esta alteração corrigiu essa violação.

**Violação de Regras de Nomenclatura:** : 
 -  Não foram encontradas violações nas regras de nomenclatura.

**Recomendações:** Recomendo que a equipe de testes valide a funcionalidade de busca de usuário para garantir que a alteração não impactou a funcionalidade existente. Além disso, recomendo que seja feita uma revisão de todo o código em busca de outros possíveis usos de `Statement` que possam ser substituídos por `PreparedStatement` para evitar futuras vulnerabilidades de injeção de SQL.