### PR TITLE
[GFTCodeFix]: Make sure this weak hash algorithm is not used in a sensitive context here.

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Postgres.java
+++ b/src/main/java/com/scalesec/vulnado/Postgres.java
@@ -28,21 +28,19 @@ public class Postgres {
         }
         return null;
     }
+
     public static void setup(){
         try {
             System.out.println("Setting up Database...");
             Connection c = connection();
             Statement stmt = c.createStatement();
 
-            // Create Schema
             stmt.executeUpdate("CREATE TABLE IF NOT EXISTS users(user_id VARCHAR (36) PRIMARY KEY, username VARCHAR (50) UNIQUE NOT NULL, password VARCHAR (50) NOT NULL, created_on TIMESTAMP NOT NULL, last_login TIMESTAMP)");
             stmt.executeUpdate("CREATE TABLE IF NOT EXISTS comments(id VARCHAR (36) PRIMARY KEY, username VARCHAR (36), body VARCHAR (500), created_on TIMESTAMP NOT NULL)");
 
-            // Clean up any existing data
             stmt.executeUpdate("DELETE FROM users");
             stmt.executeUpdate("DELETE FROM comments");
 
-            // Insert seed data
             insertUser("admin", "!!SuperSecretAdmin!!");
             insertUser("alice", "AlicePassword!");
             insertUser("bob", "BobPassword!");
@@ -58,31 +56,17 @@ public class Postgres {
         }
     }
 
-    // Java program to calculate MD5 hash value
-    public static String md5(String input)
-    {
+    public static String getSHA256(String input) {
         try {
-
-            // Static getInstance method is called with hashing MD5
-            MessageDigest md = MessageDigest.getInstance("MD5");
-
-            // digest() method is called to calculate message digest
-            //  of an input digest() return array of byte
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
             byte[] messageDigest = md.digest(input.getBytes());
-
-            // Convert byte array into signum representation
             BigInteger no = new BigInteger(1, messageDigest);
-
-            // Convert message digest into hex value
             String hashtext = no.toString(16);
             while (hashtext.length() < 32) {
                 hashtext = "0" + hashtext;
             }
             return hashtext;
-        }
-
-        // For specifying wrong message digest algorithms
-        catch (NoSuchAlgorithmException e) {
+        } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
     }
@@ -94,7 +78,7 @@ public class Postgres {
           pStatement = connection().prepareStatement(sql);
           pStatement.setString(1, UUID.randomUUID().toString());
           pStatement.setString(2, username);
-          pStatement.setString(3, md5(password));
+          pStatement.setString(3, getSHA256(password));
           pStatement.executeUpdate();
        } catch(Exception e) {
          e.printStackTrace();


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AImpact Bot para o fda9f123602d2c5c1a108e1dfa5e0cfa9102dff5

**Descrição:** O pull request com o título '[GFTCodeFix]: Make sure this weak hash algorithm is not used in a sensitive context here.' tem como objetivo a alteração do algoritmo de hash usado de MD5 para SHA-256 que é mais seguro. Além disso, o código teve uma limpeza geral, removendo comentários e linhas de espaçamento extra.

**Sumário:**

-  ```src/main/java/com/scalesec/vulnado/Postgres.java (modified)``` - O algoritmo de hash MD5 foi substituído por SHA-256. Removido comentários e espaços extras. Função md5 foi renomeada para getSHA256.

**Violação de Regras de Qualidade:**

-  ```src/main/java/com/scalesec/vulnado/Postgres.java``` - Não há violações identificadas.

**Violação de Regras de Segurança:**

-  ```src/main/java/com/scalesec/vulnado/Postgres.java``` - Não há violações identificadas.

**Violação de Regras de Nomenclatura:**

-  ```src/main/java/com/scalesec/vulnado/Postgres.java``` - Não há violações identificadas.

**Recomendações:** A função getSHA256 agora oferece uma segurança maior do que a função anterior md5, é recomendado aplicar testes para garantir que a função está retornando o resultado esperado e que não haja impacto em outras partes do código que utilizam esta função.