### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -12,11 +12,11 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", produces = "application/json", method = RequestMethod.GET)
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", produces = "application/json", method = RequestMethod.GET)
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the 3a0bab6f67aed6508324901a0a9b7926c8cf3105

**Description:** The pull request 604 with the title '[GFTCodeFix]: Update on src/main/java/com/scalesec/vulnado/LinksController.java' introduces changes in the annotations of two methods in the LinksController class. Specifically, it adds the method type (GET) in the `@RequestMapping` annotation for both the `links` and `links-v2` methods.

**Summary:**
- File: src/main/java/com/scalesec/vulnado/LinksController.java (modified)
    - The `@RequestMapping` annotation for the `links` method was modified to specify the HTTP method as GET.
    - The `@RequestMapping` annotation for the `links-v2` method was also updated to include the HTTP method as GET.

**Recommendations:** The changes seem straightforward and necessary for more explicit mapping of the HTTP methods to the controller's methods. The reviewer should ensure that the HTTP GET method is the intended type for these endpoints, and that the application behaves as expected when these endpoints are accessed with a GET request. 

There are no security vulnerabilities introduced or fixed by this pull request as it only deals with explicit declaration of HTTP methods for endpoints. However, ensure that the application handles GET requests appropriately and does not expose sensitive data or functionality. 

The modifications do not introduce new lines of code, hence there shouldn't be a newline at the end of the file. The absence of a newline is usually not an issue, but it is a common convention to end files with a newline to ensure compatibility with all tools that might not handle the last line correctly if it doesn't end with a newline. Consider adding it back in future commits. 

Your report will be saved in Markdown, so leave your answer in Markdown format.