### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,20 +13,20 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "http://trustedwebsite.com")
   @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "http://trustedwebsite.com")
   @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
     return Comment.create(input.username, input.body);
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "http://trustedwebsite.com")
   @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the d8a44005a6212ac3b0149d807b3d38c765e45267
**Description:** The pull request titled '[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java' contains changes to the CORS (Cross-Origin Resource Sharing) policy in the CommentsController.java file. The `@CrossOrigin` annotation has been updated from allowing all origins (`*`) to only allowing requests from "http://trustedwebsite.com". This change has been applied to three methods: `comments()`, `createComment()`, and `deleteComment()`. Additionally, a new line character at the end of the file has been removed.

**Summary:** 
- src/main/java/com/scalesec/vulnado/CommentsController.java (modified) - The CORS policy was updated to restrict requests to a trusted origin. 

**Recommendations:** Review the trusted website to ensure that it is indeed a trusted source. It's always a good practice to restrict CORS to trusted domains only, as a wildcard (`*`) can lead to security vulnerabilities. Please make sure to test the application to ensure that the CORS policy update doesn't break any functionality.

**Explanation of Vulnerabilities:** Previously, the application was exposed to potential Cross-Origin Resource Sharing (CORS) attacks as it was accepting requests from any origin. By specifying a trusted origin, the application is now less vulnerable. However, ensure that "http://trustedwebsite.com" is a trusted and secure website, otherwise, it could still pose a security risk. Always ensure the trusted website is served over HTTPS to prevent any potential man-in-the-middle attacks.