### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,20 +13,20 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "http://trustedwebsite.com") // Adjusted to a specific trusted website
   @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "http://trustedwebsite.com") // Adjusted to a specific trusted website
   @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
     return Comment.create(input.username, input.body);
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "http://trustedwebsite.com") // Adjusted to a specific trusted website
   @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 21f4684310bd02a163b67433962748d1621268e2

**Descrição:** Este Pull Request faz um update no arquivo 'CommentsController.java', onde as alterações estão focadas principalmente na restrição de origens de requisições com a anotação '@CrossOrigin'. Antes, estava permitindo qualquer origem ('*') e agora passou a permitir apenas do endereço 'http://trustedwebsite.com'.

**Sumário:** 
- Arquivo 'src/main/java/com/scalesec/vulnado/CommentsController.java' (alterado)
  - A anotação '@CrossOrigin(origins = "*")' foi substituída por '@CrossOrigin(origins = "http://trustedwebsite.com")' em três métodos: 'comments', 'createComment' e 'deleteComment'. Isso significa que as requisições para esses métodos agora são restritas apenas à origem 'http://trustedwebsite.com'.
  - No final do arquivo, foi removida uma linha em branco.

**Recomendações:** 
- Recomendo que o revisor verifique se a URL 'http://trustedwebsite.com' é realmente a origem confiável para essas requisições. 
- Sugiro também que seja testado se as requisições de outras origens estão sendo bloqueadas corretamente. 
- Além disso, é importante checar se as funcionalidades dos métodos 'comments', 'createComment' e 'deleteComment' continuam funcionando corretamente após essa alteração. 

**Explicação de Vulnerabilidades:** 
- Essa alteração visa corrigir uma vulnerabilidade de segurança, onde qualquer origem poderia fazer requisições para os métodos mencionados. Agora, apenas a origem 'http://trustedwebsite.com' tem permissão para fazer essas requisições, o que reduz o risco de ataques Cross-Origin Resource Sharing (CORS).