### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/Cowsay.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Cowsay.java
+++ b/src/main/java/com/scalesec/vulnado/Cowsay.java
@@ -2,13 +2,28 @@ package com.scalesec.vulnado;
 
 import java.io.BufferedReader;
 import java.io.InputStreamReader;
+import java.util.ArrayList;
+import java.util.List;
 
 public class Cowsay {
   public static String run(String input) {
     ProcessBuilder processBuilder = new ProcessBuilder();
-    String cmd = "/usr/games/cowsay '" + input + "'";
-    System.out.println(cmd);
-    processBuilder.command("bash", "-c", cmd);
+    
+    // Corrigindo a vulnerabilidade do comando controlado pelo usuário
+    List<String> commands = new ArrayList<String>();
+    commands.add("/usr/games/cowsay");
+    commands.add(input);
+    
+    // Corrigindo a vulnerabilidade de caminho
+    processBuilder.environment().put("PATH", "/usr/games");
+    
+    // Corrigindo a vulnerabilidade do recurso de depuração
+    boolean debug = false;
+    if(debug) {
+      System.out.println(commands);
+    }
+    
+    processBuilder.command(commands);
 
     StringBuilder output = new StringBuilder();
 


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 7bbad712ced8262c20b0e1e5e01403f722aa02ab
                                             
**Descrição:** Este pull request aborda a correção de várias vulnerabilidades no arquivo Cowsay.java. 

**Sumário:** 

- Arquivo: src/main/java/com/scalesec/vulnado/Cowsay.java (modificado) - O comando que era controlado pelo usuário foi corrigido. Antes, o comando era formado por uma string que incluía a entrada do usuário, o que poderia permitir a injeção de comandos. Agora, a entrada do usuário é adicionada como um argumento separado ao comando, o que evita a injeção de comandos.
- Foi corrigida a vulnerabilidade de caminho, ajustando a variável de ambiente PATH para um valor conhecido.
- Foi corrigida a vulnerabilidade do recurso de depuração. Antes, os comandos eram impressos no console, o que poderia expor informações sensíveis. Agora, os comandos só são impressos se a variável `debug` for verdadeira.

**Recomendações:** Recomendo que você confirme se as correções não afetam a funcionalidade pretendida do programa e se todas as vulnerabilidades foram de fato corrigidas.

**Explicação de Vulnerabilidades:** A vulnerabilidade de comando controlado pelo usuário ocorre quando a entrada do usuário é incluída diretamente em um comando que é executado. Isso pode permitir a injeção de comandos. A correção envolve a adição da entrada do usuário como um argumento separado ao comando, em vez de incluí-la na string do comando. A vulnerabilidade de caminho ocorre quando um atacante pode controlar o valor da variável de ambiente PATH, o que pode permitir a execução de comandos não intencionais. A correção envolve a definição do valor da variável PATH para um valor conhecido. A vulnerabilidade de recurso de depuração ocorre quando informações sensíveis são expostas através de mensagens de depuração. A correção envolve a restrição da impressão de comandos a casos em que a depuração é necessária.