### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -8,16 +8,16 @@ import java.util.List;
 import java.io.Serializable;
 import java.io.IOException;
 
-
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
+  public List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
+
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
+  public List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o ef999b4eac1f50e11ae6dce7659a8cb6c1b9c963
**Descrição:** Este Pull Request atualiza o arquivo 'LinksController.java', implementando melhorias na maneira como as rotas são tratadas no código. 

**Sumário:**
- Arquivo 'src/main/java/com/scalesec/vulnado/LinksController.java' (modificado)
  - As rotas '/links' e '/links-v2' agora especificam explicitamente que usam o método GET.
  - As funções 'links' e 'linksV2' foram modificadas para serem 'public', permitindo que sejam acessadas de fora da classe 'LinksController'.

**Recomendações:** Recomendo a revisão das alterações feitas para confirmar se o comportamento esperado das rotas '/links' e '/links-v2' permanece o mesmo após as modificações. Além disso, é importante garantir que não haja problemas de segurança advindos da mudança das funções 'links' e 'linksV2' para 'public'. 

Não foram encontradas vulnerabilidades de segurança neste Pull Request.