### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/Postgres.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Postgres.java
+++ b/src/main/java/com/scalesec/vulnado/Postgres.java
@@ -2,7 +2,7 @@ package com.scalesec.vulnado;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.math.BigInteger;
+import java.security.SecureRandom;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.sql.PreparedStatement;
@@ -22,15 +22,14 @@ public class Postgres {
             return DriverManager.getConnection(url,
                     System.getenv("PGUSER"), System.getenv("PGPASSWORD"));
         } catch (Exception e) {
-            e.printStackTrace();
             System.err.println(e.getClass().getName()+": "+e.getMessage());
             System.exit(1);
         }
         return null;
     }
+    
     public static void setup(){
         try {
-            System.out.println("Setting up Database...");
             Connection c = connection();
             Statement stmt = c.createStatement();
 
@@ -58,31 +57,18 @@ public class Postgres {
         }
     }
 
-    // Java program to calculate MD5 hash value
-    public static String md5(String input)
+    // Java program to calculate SHA-256 hash value
+    public static String sha256(String input)
     {
         try {
-
-            // Static getInstance method is called with hashing MD5
-            MessageDigest md = MessageDigest.getInstance("MD5");
-
-            // digest() method is called to calculate message digest
-            //  of an input digest() return array of byte
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
             byte[] messageDigest = md.digest(input.getBytes());
-
-            // Convert byte array into signum representation
-            BigInteger no = new BigInteger(1, messageDigest);
-
-            // Convert message digest into hex value
-            String hashtext = no.toString(16);
-            while (hashtext.length() < 32) {
-                hashtext = "0" + hashtext;
+            StringBuilder sb = new StringBuilder();
+            for (int i = 0; i < messageDigest.length; i++) {
+                sb.append(Integer.toString((messageDigest[i] & 0xff) + 0x100, 16).substring(1));
             }
-            return hashtext;
-        }
-
-        // For specifying wrong message digest algorithms
-        catch (NoSuchAlgorithmException e) {
+            return sb.toString();
+        } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
     }
@@ -94,7 +80,7 @@ public class Postgres {
           pStatement = connection().prepareStatement(sql);
           pStatement.setString(1, UUID.randomUUID().toString());
           pStatement.setString(2, username);
-          pStatement.setString(3, md5(password));
+          pStatement.setString(3, sha256(password));
           pStatement.executeUpdate();
        } catch(Exception e) {
          e.printStackTrace();


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o e1f9ff356baff0bd7de556207beab02f69ebbc2d

**Descrição:** O pull request atualiza a classe Postgres.java do projeto. As alterações principais incluem a modificação do algoritmo de hash de senhas de MD5 para SHA-256, aumentando a segurança de armazenamento de senhas. Além disso, foram removidos alguns System.out.println() e e.printStackTrace(), melhorando a legibilidade do código e a segurança, já que informações sensíveis podem ser exibidas nos logs de erro.

**Sumário:**
- src/main/java/com/scalesec/vulnado/Postgres.java (modificado)
  - Substituição do algoritmo de hash de MD5 para SHA-256
  - Remoção de chamadas System.out.println() e e.printStackTrace()
  - Pequenas alterações na formatação do código

**Recomendações:** Recomendo que o revisor teste a aplicação para garantir que a mudança no algoritmo de hash não quebrou nenhuma funcionalidade, especialmente aquelas relacionadas a autenticação e manipulação de senhas. Além disso, revisar a remoção dos System.out.println() e e.printStackTrace() para verificar se nenhuma informação crucial para debug foi perdida.

**Explicação de Vulnerabilidades:** O uso do algoritmo MD5 para o hash de senhas é considerado inseguro, pois é vulnerável a ataques de força bruta e colisões de hash. A mudança para o SHA-256 aumenta a segurança. A remoção do e.printStackTrace() também melhora a segurança, pois evita a exposição de informações sensíveis nos logs de erro.