### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,20 +13,21 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
+  // Substitua "trusted-origin.com" pelo domínio que você deseja permitir
+  @CrossOrigin(origins = "http://trusted-origin.com") 
   @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "http://trusted-origin.com")
   @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
     return Comment.create(input.username, input.body);
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "http://trusted-origin.com")
   @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o e009da9f81b2a926b5c0eaa57595972c61122a93
                                             
**Descrição:** Este Pull Request altera a configuração do CORS em vários métodos do arquivo CommentsController.java. Antes, qualquer origem era permitida graças ao uso de "*", agora a origem permitida é específica para "http://trusted-origin.com".

**Sumario:** 
- src/main/java/com/scalesec/vulnado/CommentsController.java (modificado) - Os métodos "comments", "createComment" e "deleteComment" tiveram suas anotações @CrossOrigin modificadas para permitir solicitações apenas de "http://trusted-origin.com". A linha comentada foi adicionada para instruir os desenvolvedores a substituir o domínio permitido conforme necessário. Além disso, foi removida uma linha em branco no final do arquivo.

**Recomendações:** 
- Verifique se "http://trusted-origin.com" é realmente o domínio que queremos permitir. Se não for, substitua-o pelo domínio correto.
- Garanta que essa mudança não quebre nenhuma funcionalidade existente que dependa de outras origens.
- Certifique-se de que todos os desenvolvedores estejam cientes dessa mudança e saibam como ajustar o domínio permitido, se necessário.

**Explicação de Vulnerabilidades:** 
A vulnerabilidade corrigida aqui é uma política de CORS muito permissiva. Antes dessa alteração, qualquer origem poderia fazer solicitações para esses endpoints, o que é uma prática de segurança ruim. Ao restringir as origens permitidas, reduzimos a superfície de ataque desses endpoints.