### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,16 +1,20 @@
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import javax.crypto.SecretKey;
 
 public class User {
-  public String id, username, hashedPassword;
+  private static final Logger LOGGER = Logger.getLogger(User.class.getName());
+
+  private String id;
+  private String username;
+  private String hashedPassword;
 
   public User(String id, String username, String hashedPassword) {
     this.id = id;
@@ -18,10 +22,21 @@ public class User {
     this.hashedPassword = hashedPassword;
   }
 
+  public String getId() {
+    return id;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getHashedPassword() {
+    return hashedPassword;
+  }
+
   public String token(String secret) {
     SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
-    String jws = Jwts.builder().setSubject(this.username).signWith(key).compact();
-    return jws;
+    return Jwts.builder().setSubject(this.username).signWith(key).compact();
   }
 
   public static void assertAuth(String secret, String token) {
@@ -31,34 +46,29 @@ public class User {
         .setSigningKey(key)
         .parseClaimsJws(token);
     } catch(Exception e) {
-      e.printStackTrace();
+      LOGGER.log(Level.SEVERE, e.getMessage(), e);
       throw new Unauthorized(e.getMessage());
     }
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
     User user = null;
-    try {
-      Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
-      System.out.println("Opened database successfully");
+    try (Connection cxn = Postgres.connection()) {
+      String query = "select * from users where username = ? limit 1";
+      PreparedStatement stmt = cxn.prepareStatement(query);
+      stmt.setString(1, un);
+      LOGGER.log(Level.INFO, "Opened database successfully");
 
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      ResultSet rs = stmt.executeQuery();
       if (rs.next()) {
-        String user_id = rs.getString("user_id");
+        String userId = rs.getString("user_id");
         String username = rs.getString("username");
         String password = rs.getString("password");
-        user = new User(user_id, username, password);
+        user = new User(userId, username, password);
       }
-      cxn.close();
     } catch (Exception e) {
-      e.printStackTrace();
-      System.err.println(e.getClass().getName()+": "+e.getMessage());
-    } finally {
-      return user;
-    }
+      LOGGER.log(Level.SEVERE, e.getMessage(), e);
+    } 
+    return user;
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o e3eddc0800cb6e17bbcc98ac4a2aac42caa0d424

**Descrição:** Este pull request contém uma série de mudanças no arquivo `User.java` que melhoram a qualidade do código, aumentam a segurança e facilitam a manutenção.

**Sumário:**
- `src/main/java/com/scalesec/vulnado/User.java` (alterado): 
   - Adicionado o uso de `PreparedStatement` em vez de `Statement` para evitar ataques de injeção de SQL. 
   - Refatorado o código para usar logs em vez de imprimir exceções, o que melhora a rastreabilidade e a depuração.
   - Modificado o modificador de acesso dos campos de `public` para `private` e criado métodos getter, o que aumenta o encapsulamento.
   - Removido importações desnecessárias, o que melhora a legibilidade do código.
   - Encapsulado o código que lida com conexão ao banco de dados em um bloco try-with-resources, garantindo que a conexão seja fechada mesmo em caso de exceções.

**Recomendações:** Recomendo revisar as alterações para garantir que a lógica do código não foi alterada de forma indesejada. Testes unitários devem ser executados para garantir que a funcionalidade permanece a mesma. Além disso, o uso de logs deve ser revisado para garantir que informações sensíveis não estejam sendo expostas nos logs.

**Explicação de Vulnerabilidades:** 
- Anteriormente, o código estava vulnerável a ataques de injeção de SQL, pois estava usando `Statement` e concatenando a entrada do usuário diretamente na consulta SQL. Isso foi corrigido usando `PreparedStatement` e definindo a entrada do usuário através do método `setString()`. 
- Além disso, o código estava imprimindo exceções diretamente, o que pode expor informações sensíveis. Agora, o código está usando logs, o que permite um melhor controle sobre quais informações são expostas e facilita a rastreabilidade. Entretanto, ainda é necessário garantir que informações sensíveis não estão sendo expostas nos logs.

