### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,11 +8,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
+import java.util.logging.Logger;
 
 
 public class LinkLister {
+  private static final Logger logger = Logger.getLogger(LinkLister.class.getName());
+  
+  private LinkLister() {
+      // Private constructor to hide the implicit public one
+  }
+
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +32,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      logger.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 0bceecb7bdd6a241ae0ab62119d6d33e983566a7

**Descrição:** Foi feita uma atualização no arquivo 'LinkLister.java' com o objetivo de aprimorar a qualidade do código e a segurança. 

**Sumário:** 

- Arquivo 'src/main/java/com/scalesec/vulnado/LinkLister.java' (modificado) - As mudanças realizadas incluem a adição de um Logger para registrar o host da URL, em vez de apenas imprimi-lo no console. Além disso, foi adicionado um construtor privado para a classe 'LinkLister' para ocultar o construtor público implícito, o que é uma boa prática de programação. A lista 'result' agora é inicializada sem a especificação de tipo 'String', aproveitando a inferência de tipo do Java. Por fim, não há mais uma nova linha no final do arquivo.

**Recomendações:** 

- Recomendo revisar as mudanças e testar o comportamento da aplicação com URLs diferentes para garantir que o Logger está funcionando corretamente e que as demais alterações não afetaram a funcionalidade original da classe. 

- Verifique se a adição do construtor privado para a classe 'LinkLister' não interfere na maneira como a classe é usada em outras partes do código. 

- Confirme se a remoção da especificação de tipo 'String' na inicialização da lista 'result' não causa problemas de compilação ou execução.

- Verifique se a ausência de uma nova linha no final do arquivo não causa problemas de compatibilidade ou leitura em diferentes sistemas operacionais ou editores de texto.