### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,22 +1,19 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
 
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o f915adebbbac97f28753df7f1e214cef14c2154d

**Descrição:** Este Pull Request (PR) faz algumas alterações no arquivo `LinksController.java`. A maioria dessas alterações são remoções de importações desnecessárias, o que ajuda a tornar o código mais limpo e eficiente. Além disso, os métodos de mapeamento de solicitações foram alterados para especificar o método GET.

**Sumário:**

- Arquivo `src/main/java/com/scalesec/vulnado/LinksController.java` (modificado)
  - Removidas as importações para `org.springframework.boot.*`, `org.springframework.http.HttpStatus` e `java.io.Serializable`, que não estavam sendo usadas.
  - Alterado o mapeamento de solicitação para os métodos `links` e `linksV2` para especificar o método GET.

**Recomendações:** Recomendo que as alterações sejam testadas localmente para garantir que não haja nenhum efeito colateral indesejado. Embora as importações removidas pareçam não estar sendo usadas, é sempre uma boa prática garantir que a remoção delas não afete outras partes do código. Além disso, a alteração no mapeamento de solicitações deve ser verificada para garantir que as solicitações GET ainda estão sendo processadas corretamente.

**Explicação de Vulnerabilidades:** Nenhuma vulnerabilidade foi encontrada ou corrigida com essas alterações. 

Lembre-se, o seu report será salvo em Markdown, então deixe sua resposta no formato Markdown.