### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -7,16 +7,17 @@ import org.springframework.boot.autoconfigure.*;
 import java.util.List;
 import java.io.Serializable;
 import java.io.IOException;
+import org.springframework.web.bind.annotation.RequestMethod;
 
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for 963b03fc104cbb879d2e8b934b65f1e3a2b10a5b

**Description:** This pull request modifies the `LinksController.java` file, specifically the annotations for the `/links` and `/links-v2` routes. The `@RequestMapping` annotations have been updated to explicitly specify the HTTP method as GET, and the production of 'application/json' response type.

**Summary:** 
- `src/main/java/com/scalesec/vulnado/LinksController.java` (modified) - The `@RequestMapping` annotations for the `/links` and `/links-v2` methods have been updated to include the RequestMethod.GET specification. This change clarifies that these endpoints are intended to handle GET requests. 

**Recommendations:** Please verify if these changes align with the desired functionality for these endpoints. If these endpoints are meant to support other HTTP methods beyond GET, this change might limit their functionality. A test hitting these endpoints with a GET request should be carried out to ensure that they are working as expected.

**Vulnerabilities Explanation:** Not Applicable in this context. No security vulnerabilities have been introduced or resolved in this pull request.