### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,20 +13,20 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "http://trustedwebsite.com") 
   @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "http://trustedwebsite.com")
   @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
     return Comment.create(input.username, input.body);
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "http://trustedwebsite.com")
   @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for a47e3df5cfa0fb07520cb6101476e58e5d269c80

**Description:** This pull request titled '[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java' includes changes aimed at improving the security of the application by restricting Cross Origin Resource Sharing (CORS) policy. The update replaces the wildcard (*) which allowed requests from any origin, to only allow requests from "http://trustedwebsite.com". This change has been applied on three methods within the CommentsController class, which are the 'comments', 'createComment', and 'deleteComment' methods.

**Summary:** 
- `src/main/java/com/scalesec/vulnado/CommentsController.java` (modified): CORS policy updated for three methods to restrict origins to "http://trustedwebsite.com" instead of "*". No newline at the end of the file.

**Recommendations:** Reviewer should ensure that the trusted website "http://trustedwebsite.com" is indeed a trusted source. Additionally, the impact of this change on the application functionality should be tested, especially if the application is expected to receive requests from multiple or different origins. 

**Explanation of Vulnerabilities:** Previously, the CORS policy was set to allow any origin which can expose the application to Cross-Site Request Forgery (CSRF) attacks. By specifying a trusted origin, it limits the potential attack surface. However, ensure that "http://trustedwebsite.com" is a trusted and secure website.