### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -12,11 +12,11 @@ import java.io.IOException;
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
   List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
   List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for commit ID: dcf5e9fc562b44358f23f826ff31a1acbb9cacf6

**Description:** This pull request is about a modification in the LinksController.java file where the `@RequestMapping` annotations for the `links` and `links-v2` methods have been updated to specify the request method type as GET and the produced response type as "application/json".

**Summary:** 

- File `src/main/java/com/scalesec/vulnado/LinksController.java` (modified)
    - `@RequestMapping` annotation for both `links` and `links-v2` methods has been updated to include `method = RequestMethod.GET` and `produces = "application/json"` attributes.
    - No newline at the end of the file.

**Recommendations:** 

- Please make sure that the changes align with the project's best practices and guidelines.
- Check the functionality of the `links` and `links-v2` methods to ensure that they work as expected after the change.
- Consider adding a newline at the end of the file, as it is a common coding convention to ensure smooth interoperability between different text editors and systems.

Your report will be saved in Markdown, so please leave your response in Markdown format.