### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/Postgres.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/Postgres.java
+++ b/src/main/java/com/scalesec/vulnado/Postgres.java
@@ -2,7 +2,7 @@ package com.scalesec.vulnado;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
-import java.math.BigInteger;
+import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.sql.PreparedStatement;
@@ -23,14 +23,13 @@ public class Postgres {
                     System.getenv("PGUSER"), System.getenv("PGPASSWORD"));
         } catch (Exception e) {
             e.printStackTrace();
-            System.err.println(e.getClass().getName()+": "+e.getMessage());
             System.exit(1);
         }
         return null;
     }
+    
     public static void setup(){
         try {
-            System.out.println("Setting up Database...");
             Connection c = connection();
             Statement stmt = c.createStatement();
 
@@ -53,36 +52,24 @@ public class Postgres {
             insertComment("alice", "OMG so cute!");
             c.close();
         } catch (Exception e) {
-            System.out.println(e);
             System.exit(1);
         }
     }
 
-    // Java program to calculate MD5 hash value
-    public static String md5(String input)
-    {
+    public static String getSHA256Hash(String input) {
         try {
-
-            // Static getInstance method is called with hashing MD5
-            MessageDigest md = MessageDigest.getInstance("MD5");
-
-            // digest() method is called to calculate message digest
-            //  of an input digest() return array of byte
-            byte[] messageDigest = md.digest(input.getBytes());
-
-            // Convert byte array into signum representation
-            BigInteger no = new BigInteger(1, messageDigest);
-
-            // Convert message digest into hex value
-            String hashtext = no.toString(16);
-            while (hashtext.length() < 32) {
-                hashtext = "0" + hashtext;
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] encodedhash = digest.digest(input.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hexString = new StringBuilder(2 * encodedhash.length);
+            for (int i = 0; i < encodedhash.length; i++) {
+                String hex = Integer.toHexString(0xff & encodedhash[i]);
+                if(hex.length() == 1) {
+                    hexString.append('0');
+                }
+                hexString.append(hex);
             }
-            return hashtext;
-        }
-
-        // For specifying wrong message digest algorithms
-        catch (NoSuchAlgorithmException e) {
+            return hexString.toString();
+        } catch (NoSuchAlgorithmException e) {
             throw new RuntimeException(e);
         }
     }
@@ -94,7 +81,7 @@ public class Postgres {
           pStatement = connection().prepareStatement(sql);
           pStatement.setString(1, UUID.randomUUID().toString());
           pStatement.setString(2, username);
-          pStatement.setString(3, md5(password));
+          pStatement.setString(3, getSHA256Hash(password));
           pStatement.executeUpdate();
        } catch(Exception e) {
          e.printStackTrace();


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for 64115cc56663130b786bd8a4bf32ec9f575e85b9

**Description:** This pull request contains updates made to the 'src/main/java/com/scalesec/vulnado/Postgres.java' file. The changes mainly revolve around the hashing technique used for storing passwords and the removal of some print statements.

**Summary:** 
- src/main/java/com/scalesec/vulnado/Postgres.java (modified) - The import statement for 'java.math.BigInteger' has been replaced with 'java.nio.charset.StandardCharsets'. The hashing technique for passwords has been changed from MD5 to SHA-256, hence the method name change from 'md5' to 'getSHA256Hash'. The print statements that were present in the 'connection()' and 'setup()' methods have been removed. In addition, the method 'md5' has been replaced by 'getSHA256Hash' in the 'insertUser' method.

**Recommendations:** Review the change from MD5 to SHA-256 hashing technique as it is more secure. Reviewer should test the application to ensure the password hashing and storage works as expected and there's no negative impact on the application due to the removal of print statements. 

**Vulnerabilities Explanation:** MD5 is a widely used cryptographic hash function that produces a 128-bit (16-byte) hash value. It is commonly used to verify data integrity. MD5 is considered to be a weak hash function as it is susceptible to hash collisions. A hash collision occurs when two different input values produce the same hash output. This makes the MD5 hash function unsuitable for functions such as SSL certificates or encryption that rely on a unique hash value. In this pull request, MD5 hashing has been replaced with SHA-256 which is currently deemed secure against collision attacks and is thus more secure for password storage.