### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,20 +13,20 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "http://trustedwebsite.com") // Adjusted to specific trusted origin
   @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "http://trustedwebsite.com") // Adjusted to specific trusted origin
   @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
     return Comment.create(input.username, input.body);
   }
 
-  @CrossOrigin(origins = "*")
+  @CrossOrigin(origins = "http://trustedwebsite.com") // Adjusted to specific trusted origin
   @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Generated by GFT AI Impact Bot for the commit db544344fe54d51bb9849e00641f8d01b802337a

**Description:** This pull request modifies the `CommentsController.java` class. The changes were made to enhance the security of the cross-origin resource sharing (CORS) policy. Previously, the `@CrossOrigin` annotation was set to accept requests from any origin (`*`). Now, it has been adjusted to only allow requests from a specific trusted origin (`http://trustedwebsite.com`).

**Summary:** 
- `src/main/java/com/scalesec/vulnado/CommentsController.java` (modified) - The `@CrossOrigin` annotation in three methods (`comments`, `createComment`, `deleteComment`) has been updated to only accept requests from `http://trustedwebsite.com`. This change restricts the CORS policy to a trusted origin, thereby improving security.

**Recommendations:** Ensure that `http://trustedwebsite.com` is indeed a trusted origin and is correctly spelled to prevent misconfigurations. Also, ensure that the other services are aware of this change and are capable of handling this restriction. It would be wise to add automated tests to verify the CORS policy is functioning as expected.

Please note that the last line shows `\ No newline at end of file`, indicating that a newline was removed at the end of the file. It's a common practice to end files with a newline, as some tools require this to function properly. Consider adding a newline back at the end of the file.