### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -8,16 +8,17 @@ import java.util.List;
 import java.io.Serializable;
 import java.io.IOException;
 
-
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
-    return LinkLister.getLinks(url);
-  }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
-    return LinkLister.getLinksV2(url);
-  }
+
+    @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
+    public List<String> links(@RequestParam String url) throws IOException{
+        return LinkLister.getLinks(url);
+    }
+
+    @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
+    public List<String> linksV2(@RequestParam String url) throws BadRequest{
+        return LinkLister.getLinksV2(url);
+    }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o e83e920f1e82dbb864679784293578be72c3f775
**Descrição:** Neste Pull Request, foram feitas alterações no arquivo LinksController.java, especificamente nos métodos de requisição HTTP. Anteriormente, os métodos não especificavam o tipo de requisição (GET, POST, etc), e agora isso foi corrigido.

**Sumario:**

- src/main/java/com/scalesec/vulnado/LinksController.java (modificado) - Adicionou-se especificação do tipo de método HTTP nas requisições ("/links" e "/links-v2"), que agora são do tipo GET. Além disso, os métodos agora são públicos.

**Recomendações:** 

Revisores devem testar a funcionalidade das requisições GET para os endereços "/links" e "/links-v2" para garantir que elas estão funcionando como esperado após a mudança. É importante garantir que a visibilidade pública dos métodos não introduza nenhuma vulnerabilidade de segurança. 

Nenhuma vulnerabilidade de segurança foi identificada nesta revisão.