### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,11 +8,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
-
+import java.util.logging.Logger;
 
 public class LinkLister {
+  
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
+  
+  private LinkLister() {
+    //This private constructor is defined to hide the implicit public one.
+  }
+  
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>(); // Replace the type specification in this constructor call with the diamond operator ("<>").
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -23,9 +30,9 @@ public class LinkLister {
 
   public static List<String> getLinksV2(String url) throws BadRequest {
     try {
-      URL aUrl= new URL(url);
+      URL aUrl = new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host); //Replace this use of System.out by a logger.
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o ca9db63d6fa26ecef3e5d3bac387a0e2b3b695ab

**Descrição:** Este Pull Request faz uma série de refatorações no arquivo `LinkLister.java` com o objetivo de melhorar a qualidade do código e seguir boas práticas de programação.

**Sumário:** 

- `src/main/java/com/scalesec/vulnado/LinkLister.java` (modificado): Foram feitas várias alterações no código:
  - Importação da biblioteca `java.util.logging.Logger`;
  - Adicionado um construtor privado à classe `LinkLister` para esconder o construtor público implícito;
  - Substituição da especificação de tipo na chamada do construtor de `ArrayList<String>` para o operador diamante `<>`, que é uma prática recomendada desde o Java 7 para tornar o código mais legível;
  - Substituição do `System.out.println(host)` por `LOGGER.info(host)`, que é uma prática recomendada para melhor rastreabilidade e gestão dos logs do sistema.

**Recomendações:** Recomendo que o revisor verifique atentamente as alterações propostas e assegure que elas estão de acordo com as melhores práticas de programação. Além disso, sugiro que sejam realizados testes para garantir que as funcionalidades `getLinks` e `getLinksV2` continuam a funcionar como esperado após as modificações. 

Não foram encontradas vulnerabilidades de segurança neste Pull Request.