### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinksController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinksController.java
+++ b/src/main/java/com/scalesec/vulnado/LinksController.java
@@ -1,23 +1,21 @@
 package com.scalesec.vulnado;
 
-import org.springframework.boot.*;
-import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.boot.autoconfigure.*;
 import java.util.List;
-import java.io.Serializable;
 import java.io.IOException;
-
 
 @RestController
 @EnableAutoConfiguration
 public class LinksController {
-  @RequestMapping(value = "/links", produces = "application/json")
-  List<String> links(@RequestParam String url) throws IOException{
+
+  @RequestMapping(value = "/links", method = RequestMethod.GET, produces = "application/json")
+  public List<String> links(@RequestParam String url) throws IOException{
     return LinkLister.getLinks(url);
   }
-  @RequestMapping(value = "/links-v2", produces = "application/json")
-  List<String> linksV2(@RequestParam String url) throws BadRequest{
+
+  @RequestMapping(value = "/links-v2", method = RequestMethod.GET, produces = "application/json")
+  public List<String> linksV2(@RequestParam String url) throws BadRequest{
     return LinkLister.getLinksV2(url);
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o d4ccea3f97af5eb29ac601c47bbf9d0a8ed389f6

**Descrição:** Este Pull Request faz várias alterações no arquivo `LinksController.java`, que faz parte do pacote `com.scalesec.vulnado`. As alterações são principalmente a remoção de alguns imports que não estavam sendo utilizados, a adição do método GET nas anotações `@RequestMapping` e a modificação dos métodos `links` e `linksV2` para serem métodos públicos.

**Sumário:** 
- Arquivo `src/main/java/com/scalesec/vulnado/LinksController.java` (alterado): Foram removidos os imports `org.springframework.boot.*`, `org.springframework.http.HttpStatus` e `java.io.Serializable`, que não estavam sendo utilizados. As anotações `@RequestMapping` dos métodos `links` e `linksV2` agora especificam o método GET. Além disso, os métodos `links` e `linksV2` foram alterados para serem públicos.

**Recomendações:** Por favor, revise as mudanças para confirmar se as alterações não afetam a funcionalidade do código. Como os métodos foram alterados para serem públicos, é importante verificar se isso não introduz nenhuma vulnerabilidade de segurança. Além disso, os testes devem ser realizados para garantir que os métodos `links` e `linksV2` funcionem corretamente com as alterações. 

**Explicação de Vulnerabilidades:** Nenhuma vulnerabilidade de segurança aparente foi introduzida ou corrigida com essas alterações. No entanto, a mudança dos métodos para públicos poderia potencialmente expor a funcionalidade que anteriormente estava restrita. Recomenda-se uma revisão de segurança adicional para confirmar.