### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/LinkLister.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/LinkLister.java
+++ b/src/main/java/com/scalesec/vulnado/LinkLister.java
@@ -8,11 +8,18 @@ import java.util.ArrayList;
 import java.util.List;
 import java.io.IOException;
 import java.net.*;
-
+import java.util.logging.Logger;
 
 public class LinkLister {
+
+  private static final Logger LOGGER = Logger.getLogger(LinkLister.class.getName());
+
+  private LinkLister() {
+    // This constructor is intentionally empty, as this class should not be instantiated.
+  }
+
   public static List<String> getLinks(String url) throws IOException {
-    List<String> result = new ArrayList<String>();
+    List<String> result = new ArrayList<>();
     Document doc = Jsoup.connect(url).get();
     Elements links = doc.select("a");
     for (Element link : links) {
@@ -25,7 +32,7 @@ public class LinkLister {
     try {
       URL aUrl= new URL(url);
       String host = aUrl.getHost();
-      System.out.println(host);
+      LOGGER.info(host);
       if (host.startsWith("172.") || host.startsWith("192.168") || host.startsWith("10.")){
         throw new BadRequest("Use of Private IP");
       } else {


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 13faca205d7bb3282d1d21a5b86c4416700a3f13

**Descrição:** Neste Pull Request, foram feitas algumas alterações na classe `LinkLister.java`. As mudanças incluem a adição de um logger, a modificação da maneira como os links são impressos e a adição de um construtor privado para impedir a instanciação da classe.

**Sumario:** 

- arquivo `src/main/java/com/scalesec/vulnado/LinkLister.java` (alterado)
   - Foi adicionado um `Logger` para a classe `LinkLister.java` para lidar com a impressão de mensagens.
   - O método de impressão `System.out.println(host)` foi substituído por `LOGGER.info(host)`.
   - Foi adicionado um construtor privado para a classe `LinkLister.java`. Este construtor está vazio e a intenção é impedir que esta classe seja instanciada.

**Recomendações:** Recomendo que o revisor confirme se a adição do `Logger` foi bem-sucedida e se a mudança no método de impressão não causará problemas. Além disso, é importante garantir que a adição do construtor privado não causará problemas inesperados, já que agora a classe não pode ser instanciada. 

Por fim, é interessante verificar se a remoção da nova linha no final do arquivo foi intencional e se isso não causará problemas futuros.