### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,29 +13,45 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  @CrossOrigin(origins = "http://localhost:3000") 
+  @GetMapping(value = "/comments", produces = "application/json")
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  @CrossOrigin(origins = "http://localhost:3000") 
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json")
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
-    return Comment.create(input.username, input.body);
+    return Comment.create(input.getUsername(), input.getBody());
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  @CrossOrigin(origins = "http://localhost:3000") 
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json")
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  private String username;
+  private String body;
+
+  public String getUsername() {
+    return username;
+  }
+
+  public void setUsername(String username) {
+    this.username = username;
+  }
+
+  public String getBody() {
+    return body;
+  }
+
+  public void setBody(String body) {
+    this.body = body;
+  }
 }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o a8be0cc841d09980e5b91092e582216c9586057a

**Descrição:** Este Pull Request faz atualizações significativas no arquivo `CommentsController.java`. Principalmente, ele atualiza os métodos HTTP, restringe as origens de CORS para `http://localhost:3000`, e modifica a classe `CommentRequest` para usar métodos getter e setter.

**Sumario:**

- `src/main/java/com/scalesec/vulnado/CommentsController.java` (modificado)

    - As anotações `@CrossOrigin` foram alteradas de `*` para `http://localhost:3000` para restringir as solicitações de CORS a um domínio específico.

    - Os métodos HTTP foram alterados de `@RequestMapping` para `@GetMapping`, `@PostMapping` e `@DeleteMapping` para uma melhor legibilidade e conformidade com as convenções modernas do Spring.

    - A classe `CommentRequest` agora usa métodos getter e setter (`getUsername`, `setUsername`, `getBody`, `setBody`) para acessar e modificar os campos `username` e `body`.

**Recomendações:** 

Revisar a alteração do `@CrossOrigin` para garantir que a restrição à `http://localhost:3000` esteja em conformidade com a política de segurança CORS da aplicação. Além disso, assegurar-se de que a mudança para métodos getter e setter na classe `CommentRequest` não quebra a funcionalidade existente. Recomenda-se testar todas as rotas modificadas para garantir que elas funcionam como esperado após essas alterações.