### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,16 +1,19 @@
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.util.logging.Logger;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import javax.crypto.SecretKey;
 
 public class User {
-  public String id, username, hashedPassword;
+  private static final Logger logger = Logger.getLogger(User.class.getName());
+
+  private String id;
+  private String username;
+  private String hashedPassword;
 
   public User(String id, String username, String hashedPassword) {
     this.id = id;
@@ -18,10 +21,21 @@ public class User {
     this.hashedPassword = hashedPassword;
   }
 
+  public String getId() {
+    return id;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getHashedPassword() {
+    return hashedPassword;
+  }
+
   public String token(String secret) {
     SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
-    String jws = Jwts.builder().setSubject(this.username).signWith(key).compact();
-    return jws;
+    return Jwts.builder().setSubject(this.username).signWith(key).compact(); // Vulnerability ID: Immediately return this expression instead of assigning it to the temporary variable "jws".
   }
 
   public static void assertAuth(String secret, String token) {
@@ -31,34 +45,31 @@ public class User {
         .setSigningKey(key)
         .parseClaimsJws(token);
     } catch(Exception e) {
-      e.printStackTrace();
+      logger.severe(e.getMessage());
       throw new Unauthorized(e.getMessage());
     }
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
     User user = null;
-    try {
-      Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
-      System.out.println("Opened database successfully");
+    try (Connection cxn = Postgres.connection();
+      PreparedStatement stmt = cxn.prepareStatement("select * from users where username = ? limit 1")) { // Vulnerability ID: Change this code to not construct SQL queries directly from user-controlled data.
+      
+      stmt.setString(1, un);
 
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      logger.info("Opened database successfully");
+
+      ResultSet rs = stmt.executeQuery();
+
       if (rs.next()) {
-        String user_id = rs.getString("user_id");
+        String userId = rs.getString("user_id"); // Vulnerability ID: Rename this local variable to match the regular expression '^[a-z][a-zA-Z0-9]*$'.
         String username = rs.getString("username");
         String password = rs.getString("password");
-        user = new User(user_id, username, password);
+        user = new User(userId, username, password);
       }
-      cxn.close();
     } catch (Exception e) {
-      e.printStackTrace();
-      System.err.println(e.getClass().getName()+": "+e.getMessage());
-    } finally {
-      return user;
+      logger.severe(e.getClass().getName()+": "+e.getMessage());
     }
+    return user; // Vulnerability ID: Remove this return statement from this finally block.
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 80ea5da941eace7af89092a6d88352528e941039

**Descrição:** Este pull request apresenta uma série de atualizações no arquivo `User.java`, com foco em melhorar a segurança, legibilidade do código e seguir as boas práticas de programação. As alterações incluem a substituição de `Statement` por `PreparedStatement` para consultas SQL, a adição de um logger, a alteração de variáveis públicas para privadas com métodos de acesso (getters) e a correção de um problema de injeção de SQL.

**Sumário:**

- `src/main/java/com/scalesec/vulnado/User.java` (alterado): 

  - Substituída a classe `Statement` por `PreparedStatement` para prevenir injeções SQL.
  - Adicionado um `Logger` para melhorar a rastreabilidade dos eventos.
  - As variáveis `id`, `username` e `hashedPassword` foram alteradas de públicas para privadas e foram adicionados os respectivos métodos getters.
  - O método `token` foi refatorado para retornar imediatamente a expressão.
  - O método `fetch` foi refatorado para usar `try-with-resources`, melhorando o gerenciamento de recursos.
  - As mensagens de erro agora são registradas com `logger.severe()` em vez de `e.printStackTrace()`.
  
**Recomendações:** Recomendo que as alterações sejam testadas para garantir que não haja regressões inesperadas e que todas as funcionalidades continuem funcionando como esperado após a refatoração. 

**Explicação de Vulnerabilidades:** 

  - **Injeção de SQL:** Anteriormente, a consulta SQL no método `fetch` era criada concatenando diretamente a entrada do usuário, o que poderia permitir uma injeção de SQL se a entrada do usuário não fosse adequadamente sanitizada. Agora, a consulta SQL é criada usando um `PreparedStatement`, que sanitiza a entrada do usuário.

  - **Uso inadequado de variáveis temporárias:** O método `token` foi refatorado para retornar imediatamente a expressão em vez de atribuí-la a uma variável temporária. Isso melhora a legibilidade do código e elimina uma variável desnecessária.

  - **Uso inadequado de recursos:** Anteriormente, os recursos de banco de dados não eram fechados adequadamente se ocorresse uma exceção, o que poderia levar a vazamentos de recursos. Agora, o método `fetch` usa um bloco `try-with-resources`, que garante que os recursos sejam fechados corretamente, mesmo se ocorrer uma exceção.
