### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/User.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/User.java
+++ b/src/main/java/com/scalesec/vulnado/User.java
@@ -1,16 +1,19 @@
 package com.scalesec.vulnado;
 
 import java.sql.Connection;
-import java.sql.Statement;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
+import java.util.logging.Logger;
 import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.JwtParser;
-import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.security.Keys;
 import javax.crypto.SecretKey;
 
 public class User {
-  public String id, username, hashedPassword;
+  private static final Logger LOGGER = Logger.getLogger(User.class.getName());
+
+  private String id;
+  private String username;
+  private String hashedPassword;
 
   public User(String id, String username, String hashedPassword) {
     this.id = id;
@@ -18,10 +21,21 @@ public class User {
     this.hashedPassword = hashedPassword;
   }
 
+  public String getId() {
+    return id;
+  }
+
+  public String getUsername() {
+    return username;
+  }
+
+  public String getHashedPassword() {
+    return hashedPassword;
+  }
+
   public String token(String secret) {
     SecretKey key = Keys.hmacShaKeyFor(secret.getBytes());
-    String jws = Jwts.builder().setSubject(this.username).signWith(key).compact();
-    return jws;
+    return Jwts.builder().setSubject(this.username).signWith(key).compact(); // Removed temporary variable "jws"
   }
 
   public static void assertAuth(String secret, String token) {
@@ -31,34 +45,30 @@ public class User {
         .setSigningKey(key)
         .parseClaimsJws(token);
     } catch(Exception e) {
-      e.printStackTrace();
+      LOGGER.severe(e.getMessage());
       throw new Unauthorized(e.getMessage());
     }
   }
 
   public static User fetch(String un) {
-    Statement stmt = null;
+    PreparedStatement stmt = null; // Changed Statement to PreparedStatement to prevent SQL Injection
     User user = null;
-    try {
-      Connection cxn = Postgres.connection();
-      stmt = cxn.createStatement();
-      System.out.println("Opened database successfully");
+    try (Connection cxn = Postgres.connection()) { // Added try-with-resources statement
+      LOGGER.info("Opened database successfully");
 
-      String query = "select * from users where username = '" + un + "' limit 1";
-      System.out.println(query);
-      ResultSet rs = stmt.executeQuery(query);
+      String query = "select * from users where username = ? limit 1"; // Using PreparedStatement to prevent SQL Injection
+      stmt = cxn.prepareStatement(query); // Changed createStatement to prepareStatement
+      stmt.setString(1, un); // Set username parameter
+      ResultSet rs = stmt.executeQuery();
       if (rs.next()) {
-        String user_id = rs.getString("user_id");
+        String userId = rs.getString("user_id");
         String username = rs.getString("username");
         String password = rs.getString("password");
-        user = new User(user_id, username, password);
+        user = new User(userId, username, password);
       }
-      cxn.close();
     } catch (Exception e) {
-      e.printStackTrace();
-      System.err.println(e.getClass().getName()+": "+e.getMessage());
-    } finally {
-      return user;
+      LOGGER.severe(e.getClass().getName()+": "+e.getMessage());
     }
+    return user; // Moved return statement out of finally block
   }
 }


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 03f0bfffd1b6bc465a6f15e57463e3d0297c1b9a
                                                
**Descrição:** Este Pull Request faz várias atualizações no arquivo 'src/main/java/com/scalesec/vulnado/User.java', com o objetivo de melhorar a segurança e a qualidade do código.

**Sumario:**

- src/main/java/com/scalesec/vulnado/User.java (modificado)
    - Trocou-se a implementação de `java.sql.Statement` para `java.sql.PreparedStatement` para prevenir SQL Injection.
    - A impressão de mensagens de erros foi trocada para usar Logger em vez de printStackTrace.
    - Foi adicionado um bloco try-with-resources para garantir que a conexão com o banco de dados seja fechada automaticamente.
    - A visibilidade dos atributos `id`, `username` e `hashedPassword` foi alterada para privada, e foram adicionados métodos getters correspondentes.
    - A variável temporária `jws` foi removida no método `token()`.
    - A declaração de retorno foi movida para fora do bloco finally.

**Recomendações:** Recomendo que o revisor verifique se todas as alterações estão corretas e se não há mais nenhuma vulnerabilidade de segurança no código modificado.

**Explicação de Vulnerabilidades:** 
- A utilização de `java.sql.Statement` pode levar a vulnerabilidades de SQL Injection, pois permite a execução de consultas SQL modificadas. Ao utilizar `java.sql.PreparedStatement`, essas vulnerabilidades são mitigadas, pois os parâmetros são escapados automaticamente.
- O uso do método `printStackTrace()` pode expor detalhes sensíveis do sistema, especialmente em ambientes de produção. Utilizar um `Logger` é uma prática mais segura, pois permite um controle mais granular sobre o que é registrado e onde esses registros são armazenados.
- A não utilização de um bloco try-with-resources em conexões JDBC pode resultar em vazamentos de recursos, pois a conexão pode não ser fechada corretamente em caso de erros. Com o uso de try-with-resources, a conexão é automaticamente fechada ao final do bloco.