### PR TITLE
[GFTCodeFix]:  Update on src/main/java/com/scalesec/vulnado/CommentsController.java

### DIFF
--- a/src/main/java/com/scalesec/vulnado/CommentsController.java
+++ b/src/main/java/com/scalesec/vulnado/CommentsController.java
@@ -13,29 +13,44 @@ public class CommentsController {
   @Value("${app.secret}")
   private String secret;
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.GET, produces = "application/json")
+  // Alterado por GFT AI Impact Bot
+  @CrossOrigin(origins = "*", maxAge = 3600) // Make sure that enabling CORS is safe here.
+  @GetMapping(value = "/comments", produces = "application/json") // Replace "@RequestMapping(method = RequestMethod.GET)" with "@GetMapping"
   List<Comment> comments(@RequestHeader(value="x-auth-token") String token) {
     User.assertAuth(secret, token);
     return Comment.fetch_all();
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments", method = RequestMethod.POST, produces = "application/json", consumes = "application/json")
+  // Alterado por GFT AI Impact Bot
+  @CrossOrigin(origins = "*", maxAge = 3600) // Make sure that enabling CORS is safe here.
+  @PostMapping(value = "/comments", produces = "application/json", consumes = "application/json") // Replace "@RequestMapping(method = RequestMethod.POST)" with "@PostMapping"
   Comment createComment(@RequestHeader(value="x-auth-token") String token, @RequestBody CommentRequest input) {
-    return Comment.create(input.username, input.body);
+    return Comment.create(input.getUsername(), input.getBody());
   }
 
-  @CrossOrigin(origins = "*")
-  @RequestMapping(value = "/comments/{id}", method = RequestMethod.DELETE, produces = "application/json")
+  // Alterado por GFT AI Impact Bot
+  @CrossOrigin(origins = "*", maxAge = 3600) // Make sure that enabling CORS is safe here.
+  @DeleteMapping(value = "/comments/{id}", produces = "application/json") // Replace "@RequestMapping(method = RequestMethod.DELETE)" with "@DeleteMapping"
   Boolean deleteComment(@RequestHeader(value="x-auth-token") String token, @PathVariable("id") String id) {
     return Comment.delete(id);
   }
 }
 
 class CommentRequest implements Serializable {
-  public String username;
-  public String body;
+  // Alterado por GFT AI Impact Bot
+  private String username; // Make username a static final constant or non-public and provide accessors if needed.
+  // Alterado por GFT AI Impact Bot
+  private String body; // Make body a static final constant or non-public and provide accessors if needed.
+
+  // Incluido por GFT AI Impact Bot
+  public String getUsername() {
+    return username;
+  }
+
+  // Incluido por GFT AI Impact Bot
+  public String getBody() {
+    return body;
+  }
 }
 
 @ResponseStatus(HttpStatus.BAD_REQUEST)


### PR DESCRIPTION
![gft_icon](https://www.gft.com/int/en/.resources/gft/webresources/img/gft-favicon.ico) Gerado por GFT AI Impact Bot para o 9ac019652f0da2713b4465f4aeaa82518dbe8887

**Descrição:** Este Pull Request contém alterações no arquivo `CommentsController.java`. As alterações incluem a substituição de anotações `@RequestMapping` por `@GetMapping`, `@PostMapping` e `@DeleteMapping` respectivamente. Além disso, os atributos `username` e `body` da classe `CommentRequest` foram alterados de `public` para `private` e foram adicionados métodos de acesso (getters) para esses atributos.

**Sumário:**
- src/main/java/com/scalesec/vulnado/CommentsController.java (modificado)
  - Substituição de `@RequestMapping` por `@GetMapping`, `@PostMapping` e `@DeleteMapping`
  - Adição de `maxAge = 3600` na anotação `@CrossOrigin`
  - Alteração dos atributos `username` e `body` de `public` para `private` na classe `CommentRequest`
  - Adição dos métodos `getUsername()` e `getBody()` na classe `CommentRequest`

**Recomendações:** Recomendo que o revisor verifique se a adição de `maxAge = 3600` na anotação `@CrossOrigin` é segura e se está de acordo com as políticas de segurança da aplicação. Além disso, é importante verificar se a mudança dos atributos `username` e `body` para `private` e a adição dos métodos de acesso não quebram outras partes do código que dependem desses atributos.